### PR TITLE
Changed craft name override, allows restoring defaults

### DIFF
--- a/Tie/Strings.cs
+++ b/Tie/Strings.cs
@@ -138,6 +138,7 @@ namespace Idmr.Platform.Tie
 										"Asteroid Field 2",
 										"Planet"
 									};
+		static string[] _defaultCraftType = (string[])_craftType.Clone();  //Backup to preserve original when overriding.
 		static string[] _craftAbbrv = { "",
 										 "X-W",
 										 "Y-W",
@@ -227,6 +228,7 @@ namespace Idmr.Platform.Tie
 										 "Asteroid",
 										 "Planet"
 									 };
+		static string[] _defaultCraftAbbrv = (string[])_craftAbbrv.Clone();  //Backup to preserve original when overriding.
         static string[] _rating = { "Novice",    //[JB] Fixed to mirror names in HD1W.TIE
 									 "Officer",
 									 "Veteran",
@@ -490,19 +492,24 @@ namespace Idmr.Platform.Tie
 									};
 		#endregion
 
-		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays.</summary>
-		/// <param name="craftTypes">Array of new craft types.</param>
-		/// <param name="craftAbbrv">Array of new craft abbreviations.</param>
+		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays, or restores defaults.</summary>
+		/// <param name="craftTypes">Array of new craft types, or null to restore both defaults.</param>
+		/// <param name="craftAbbrv">Array of new craft abbreviations, or null to restore both defaults.</param>
 		/// <exception cref="ArgumentException">The <see cref="Array.Length"/> of the arrays do match the originals.</exception>
-		/// <exception cref="ArgumentNullException">Either or both of the input arrays are <b>null</b>.</exception>
 		public static void OverrideShipList(string[] craftTypes, string[] craftAbbrv)
 		{
-			if (craftAbbrv == null || craftTypes == null)
-				throw new ArgumentNullException("At least one of the arrays is null, check for valid inputs.");
-			if (craftTypes.Length != _craftType.Length || craftAbbrv.Length != _craftAbbrv.Length)
-				throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
-			_craftType = craftTypes;
-			_craftAbbrv = craftAbbrv;
+			if (craftTypes != null && craftAbbrv != null)
+			{
+				if (craftTypes.Length != _defaultCraftType.Length || craftAbbrv.Length != _defaultCraftAbbrv.Length)
+					throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
+				_craftType = craftTypes;
+				_craftAbbrv = craftAbbrv;
+			}
+			else
+			{
+				_craftType = _defaultCraftType;
+				_craftAbbrv = _defaultCraftAbbrv;
+			}
 		}
 
 		/// <summary>Gets a copy of the default IFF Names</summary>

--- a/Xvt/Strings.cs
+++ b/Xvt/Strings.cs
@@ -212,6 +212,7 @@ namespace Idmr.Platform.Xvt
 										"Repair Yard",
 										"Modified Strike Cruiser"
 									};
+		static string[] _defaultCraftType = (string[])_craftType.Clone();  //Backup to preserve original when overriding.
 		static string[] _craftAbbrv = { "",
 										"X-W",
 										"Y-W",
@@ -306,6 +307,7 @@ namespace Idmr.Platform.Xvt
 										"REPYD",
 										"M/SC"
 									 };
+		static string[] _defaultCraftAbbrv = (string[])_craftAbbrv.Clone();  //Backup to preserve original when overriding.
 		static string[] _rating = { "Novice",
 									"Officer",
 									"Veteran",
@@ -553,19 +555,24 @@ namespace Idmr.Platform.Xvt
 									};
         #endregion
 
-		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays.</summary>
-		/// <param name="craftTypes">Array of new craft types.</param>
-		/// <param name="craftAbbrv">Array of new craft abbreviations.</param>
+		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays, or restores defaults.</summary>
+		/// <param name="craftTypes">Array of new craft types, or null to restore both defaults.</param>
+		/// <param name="craftAbbrv">Array of new craft abbreviations, or null to restore both defaults.</param>
 		/// <exception cref="ArgumentException">The <see cref="Array.Length"/> of the arrays do match the originals.</exception>
-		/// <exception cref="ArgumentNullException">Either or both of the input arrays are <b>null</b>.</exception>
 		public static void OverrideShipList(string[] craftTypes, string[] craftAbbrv)
 		{
-			if (craftAbbrv == null || craftTypes == null)
-				throw new ArgumentNullException("At least one of the arrays is null, check for valid inputs.");
-			if (craftTypes.Length != _craftType.Length || craftAbbrv.Length != _craftAbbrv.Length)
-				throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
-			_craftType = craftTypes;
-			_craftAbbrv = craftAbbrv;
+			if (craftTypes != null && craftAbbrv != null)
+			{
+				if (craftTypes.Length != _defaultCraftType.Length || craftAbbrv.Length != _defaultCraftAbbrv.Length)
+					throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
+				_craftType = craftTypes;
+				_craftAbbrv = craftAbbrv;
+			}
+			else
+			{
+				_craftType = _defaultCraftType;
+				_craftAbbrv = _defaultCraftAbbrv;
+			}
 		}
 
 		/// <summary>String containing all possible team prefixes</summary>

--- a/Xwa/Strings.cs
+++ b/Xwa/Strings.cs
@@ -373,6 +373,7 @@ namespace Idmr.Platform.Xwa
 										"*Planet",
 										"*Planet"
 									};
+		static string[] _defaultCraftType = (string[])_craftType.Clone();  //Backup to preserve original when overriding.
 		static string[] _craftAbbrv = { "",
 										"X-W",
 										"Y-W",
@@ -607,6 +608,7 @@ namespace Idmr.Platform.Xwa
 										"*B/Drop",
 										"*B/Drop"
 									 };
+		static string[] _defaultCraftAbbrv = (string[])_craftAbbrv.Clone();  //Backup to preserve original when overriding.
 		static string[] _rating = { "Novice",
 									"Officer",
 									"Veteran",
@@ -917,19 +919,25 @@ namespace Idmr.Platform.Xwa
 									};
 		#endregion
 
-		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays.</summary>
-		/// <param name="craftTypes">Array of new craft types.</param>
-		/// <param name="craftAbbrv">Array of new craft abbreviations.</param>
-		/// <exception cref="ArgumentException">The <see cref="Array.Length"/> of the arrays do match the originals.</exception>
-		/// <exception cref="ArgumentNullException">Either or both of the input arrays are <b>null</b>.</exception>
+		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays, or restores defaults.</summary>
+		/// <param name="craftTypes">Array of new craft types, or null to restore both defaults.</param>
+		/// <param name="craftAbbrv">Array of new craft abbreviations, or null to restore both defaults.</param>
+		/// <exception cref="ArgumentException">The <see cref="Array.Length"/> of the arrays are shorter than the originals.</exception>
 		public static void OverrideShipList(string[] craftTypes, string[] craftAbbrv)
 		{
-			if (craftAbbrv == null || craftTypes == null)
-				throw new ArgumentNullException("At least one of the arrays is null, check for valid inputs.");
-			if (craftTypes.Length != _craftType.Length || craftAbbrv.Length != _craftAbbrv.Length)
-				throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
-			_craftType = craftTypes;
-			_craftAbbrv = craftAbbrv;
+			if (craftTypes != null && craftAbbrv != null)
+			{
+				//NOTE: Craft pack mods may extend the list beyond the original length, so only check shorter length instead of unequal.
+				if (craftTypes.Length < _defaultCraftType.Length || craftAbbrv.Length < _defaultCraftAbbrv.Length)
+					throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must not be shorter than original length (" + _craftAbbrv.Length + ").");
+				_craftType = craftTypes;
+				_craftAbbrv = craftAbbrv;
+			}
+			else
+			{
+				_craftType = _defaultCraftType;
+				_craftAbbrv = _defaultCraftAbbrv;
+			}
 		}
 
 		/// <summary>Gets a copy of the shadows to be applied to a backdrop</summary>

--- a/xwing/Strings.cs
+++ b/xwing/Strings.cs
@@ -58,6 +58,7 @@ namespace Idmr.Platform.Xwing
 										"TIE Advanced",
 										"B-Wing"
 									 };
+		static string[] _defaultCraftType = (string[])_craftType.Clone();  //Backup to preserve original when overriding.
 		static string[] _craftAbbrv = { "None",
 										"X-W",
 										"Y-W",
@@ -78,6 +79,7 @@ namespace Idmr.Platform.Xwing
 										"T/A",
 										"B-W"
 									  };
+		static string[] _defaultCraftAbbrv = (string[])_craftAbbrv.Clone();  //Backup to preserve original when overriding.
 		static string[] _objectType = {   "None",
 										  "Mine1",  //[JB] IMPORTANT! Objects begin at index 18 in game.
 										  "Mine2",
@@ -360,19 +362,24 @@ namespace Idmr.Platform.Xwing
 		/// <summary>Caption used for briefing hint pages</summary>
 		public static readonly string BriefingPageHintCaption = "$>STRATEGY AND TACTICS$>FOR COMPLETING THIS MISSION$>ARE AVAILABLE.$$$>DO NOT READ THIS IF YOU WISH TO$>DISCOVER THESE FOR YOURSELF!$$$>CLICK ON THE BLACK PAGE NUMBER$>BOX TO SEE THE HINT(S).";
 
-		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays.</summary>
-		/// <param name="craftTypes">Array of new craft types.</param>
-		/// <param name="craftAbbrv">Array of new craft abbreviations.</param>
+		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays, or restores defaults.</summary>
+		/// <param name="craftTypes">Array of new craft types, or null to restore both defaults.</param>
+		/// <param name="craftAbbrv">Array of new craft abbreviations, or null to restore both defaults.</param>
 		/// <exception cref="ArgumentException">The <see cref="Array.Length"/> of the arrays do match the originals.</exception>
-		/// <exception cref="ArgumentNullException">Either or both of the input arrays are <b>null</b>.</exception>
 		public static void OverrideShipList(string[] craftTypes, string[] craftAbbrv)
 		{
-			if (craftAbbrv == null || craftTypes == null)
-				throw new ArgumentNullException("At least one of the arrays is null, check for valid inputs.");
-			if (craftTypes.Length != _craftType.Length || craftAbbrv.Length != _craftAbbrv.Length)
-				throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
-			_craftType = craftTypes;
-			_craftAbbrv = craftAbbrv;
+			if (craftTypes != null && craftAbbrv != null)
+			{
+				if (craftTypes.Length != _defaultCraftType.Length || craftAbbrv.Length != _defaultCraftAbbrv.Length)
+					throw new ArgumentException("New arrays (Types " + craftTypes.Length + ", Abbrv " + craftAbbrv.Length + ") must match original length (" + _craftAbbrv.Length + ").");
+				_craftType = craftTypes;
+				_craftAbbrv = craftAbbrv;
+			}
+			else
+			{
+				_craftType = _defaultCraftType;
+				_craftAbbrv = _defaultCraftAbbrv;
+			}
 		}
 
 		/// <summary>Gets a copy of the default IFF Names</summary>


### PR DESCRIPTION
As part of the wireframe implementation, there's a new system of handling the craft data, including craft names.  This allows the craft  names to be reset, and updated correctly if a craft pack was detected for XWA.