### PR TITLE
XvT discovered unknowns, plus XWA gg names

### DIFF
--- a/Converter.cs
+++ b/Converter.cs
@@ -118,17 +118,17 @@ namespace Idmr.Platform
                 tie.FlightGroups[i].DepartureMethod2 = miss.FlightGroups[i].DepartureMethod2;
                 #endregion ArrDep
                 #region Goals
-                if ((miss.FlightGroups[i].Goals[0].Enabled == true) && miss.FlightGroups[i].Goals[0].Team == 0)
+                if (miss.FlightGroups[i].Goals[0].GetEnabledForTeam(0))
                 {
                     tie.FlightGroups[i].Goals.PrimaryCondition = miss.FlightGroups[i].Goals[0].Condition;
                     tie.FlightGroups[i].Goals.PrimaryAmount = miss.FlightGroups[i].Goals[0].Amount;
                 }
-                if ((miss.FlightGroups[i].Goals[1].Enabled == true) && miss.FlightGroups[i].Goals[1].Team == 0)
+                if (miss.FlightGroups[i].Goals[1].GetEnabledForTeam(0))
                 {
                     tie.FlightGroups[i].Goals.SecondaryCondition = miss.FlightGroups[i].Goals[1].Condition;
                     tie.FlightGroups[i].Goals.SecondaryAmount = miss.FlightGroups[i].Goals[1].Amount;
                 }
-                if ((miss.FlightGroups[i].Goals[2].Enabled == true) && miss.FlightGroups[i].Goals[2].Team == 0)
+                if (miss.FlightGroups[i].Goals[2].GetEnabledForTeam(0))
                 {
                     tie.FlightGroups[i].Goals.BonusCondition = miss.FlightGroups[i].Goals[2].Condition;
                     tie.FlightGroups[i].Goals.BonusAmount = miss.FlightGroups[i].Goals[2].Amount;
@@ -1283,8 +1283,7 @@ namespace Idmr.Platform
                         xvt.FlightGroups[i].Goals[0].Condition = cond;
                         xvt.FlightGroups[i].Goals[0].Argument = 0;  //Must be completed
                         xvt.FlightGroups[i].Goals[0].Amount = amount;
-                        xvt.FlightGroups[i].Goals[0].Team = 0;
-                        xvt.FlightGroups[i].Goals[0].Enabled = true;
+                        xvt.FlightGroups[i].Goals[0].SetEnabledForTeam(0, true);
                         //tieGoalsCheck("FlightGroup " + i, xvt.FlightGroups[i].Goals);   //Don't need to convert the amounts, we've set them directly.
 
                         if (i == playerMothership)
@@ -1307,8 +1306,7 @@ namespace Idmr.Platform
                             xvt.FlightGroups[i].Goals[0].Condition = cond;
                             xvt.FlightGroups[i].Goals[0].Argument = argument;
                             xvt.FlightGroups[i].Goals[0].Amount = 0;  //100%
-                            xvt.FlightGroups[i].Goals[0].Team = 0;
-                            xvt.FlightGroups[i].Goals[0].Enabled = true;
+                            xvt.FlightGroups[i].Goals[0].SetEnabledForTeam(0, true);
 
                             if (role != "")
                                 xvt.FlightGroups[i].Roles[0] = role;

--- a/Mission_XvT.txt
+++ b/Mission_XvT.txt
@@ -894,7 +894,7 @@ Condition
 19	be dropped off
 1A	Destroyed in 1 hit (broken)
 1B	NOT be disabled
-1C	NOT be picked up
+1C	NOT be captured
 1D	Come and go w/o Inspection
 1E	Begin being boarded
 1F	NOT being boarded
@@ -910,7 +910,7 @@ Condition
 29	be all Player Craft
 2A	be all AI Craft
 2B	come and go
-2C	be picked up
+2C	be bagged
 2D	withdraw
 2E	be carried away
 
@@ -919,26 +919,17 @@ Notes:
 trigger is evaluated. Includes craft that haven't arrived yet. Excludes craft
 that have been destroyed by any means.
 
+0x0D/0x0E (Completed/Failed Primary Goals) and 0x11/0x12 (Completed/Failed
+Bonus Goals) If VariableType is Team, it checks the mission outcome for that
+team. In all other cases, it is true if any team has achieved victory.
+0x0F and 0x10 (Completed/Failed Secondary Goals) don't do anything.
+
 0x18 (Cannon system disabled) is true when the cannons are missing or disabled.
 Capital ships don't have a cannon subsystem, so it will always be true for
 them. Mag pulse does not damage the cannon subsystem of AI craft, but it will
 for players, so it can be used to detect a mag pulse hit on a player craft.
 
-0x1D (Destroyed w/o Inspection) Tracks craft that are destroyed (or prevented
-from arriving) without being inspected. If paired with Condition 0x27, its
-behavior is modified to track come and go without inspection, which can detect
-escaping craft.
-
-0x29 (be all Player Craft) and 0x2A (be all AI Craft) When combined with a
-VariableType of IFF or Team, has a special interaction. Instead of counting all
-craft, it counts the number of active player slots out of the total number of
-playable FGs. This allows mission design to tailor difficulty based on number
-of active players.
-
-0x0D/0x0E (Completed/Failed Primary Goals) and 0x11/0x12 (Completed/Failed
-Bonus Goals) If VariableType is Team, it checks the mission outcome for that
-team. In all other cases, it is true if any team has achieved victory.
-0x0F and 0x10 (Completed/Failed Secondary Goals) don't do anything.
+0x19 (Be dropped off) Never seems be be true, either as a trigger or goal.
 
 0x1A (Destroyed in 1 hit) A broken condition. It's supposed to be "come and
 go without being attacked" but the implementation is broken in a few ways. For
@@ -951,10 +942,26 @@ such as when using warheads), then "come-and-go" takes precendence over
 "attacked" and evaluates to success, even though it was attacked. But this bug
 only applies if the FG is one craft of one wave.
 
-0x1D (Come and go w/o Inspection) A bit strange. If used as a goal, it's
-exactly as it says. However, the statistic isn't globally tracked, so it will
-not activate for triggers unless paired with condition 0x27 for a specific
-team.
+0x1B (Not be disabled) A "come and go" condition, but is half broken. For
+triggers, it will activate even if the craft was disabled. However it does seem
+to work correctly as a goal, since being disabled is an anti-condition.
+
+0x1C (Not be captured) A "come and go" condition that actually seems to work
+correctly.
+
+0x1D (Come and go w/o Inspection) Not as straightforward as it would seem.
+Statistics per team are only tracked if the craft actually arrives, then leaves
+or is destroyed. Global statistics are only tracked if the craft comes and goes
+by proxy (mothership destroyed prior to launch, or departure ship destroyed
+after landing).
+If evaluated as a FG goal, or as a trigger paired with Condition 0x27, it uses
+the per-team statistic. Otherwise it uses the global statistic.
+
+0x1F (Not being boarded) A "come and go" condition that is tracked if the craft
+was never finished being boarded by another craft.
+
+0x21 (Not begin docking) A "come and go" condition that is tracked if the craft
+never finished boarding another craft.
 
 0x26 (Always Failed) Evaluates to failure, as opposed to merely false. If used
 for a goal, it will cause immediate failure.
@@ -971,6 +978,24 @@ trigger, which modifies the A trigger to access statistics for a specific team
 instead the grand total. Trigger B's VariableType must be set to Team. Variable
 must be set to the team index. Amount doesn't matter. The and/or boolean
 doesn't matter.
+
+FG Goals don't operate in pairs, instead they automatically use the team they
+check against. It's basically an implicit team modifier, for the few conditions
+that accept them.
+
+0x29 (be all Player Craft) and 0x2A (be all AI Craft) When combined with a
+VariableType of IFF or Team, has a special interaction. Instead of counting all
+craft, it counts the number of active player slots out of the total number of
+playable FGs. This allows mission design to tailor difficulty based on number
+of active players.
+
+0x2C (bagged) Similar to capture. The distinction is that capture is logged
+instantaneously, but being bagged requires the captured craft to enter hangar
+or hyperspace out. If a craft is picked up (such as by a Heavy Lifter), it is
+captured by the craft carrying it.
+
+0x2E (be carried away) This is a pick-up condition, but is distinct from bagged
+that it can only operate on friendly craft. They must not be captured.
 
 
 VariableType

--- a/Mission_XvT.txt
+++ b/Mission_XvT.txt
@@ -114,7 +114,7 @@ struct FlightGroup (size 0x562)
 	0x060	BYTE	LeaderSpacing
 	0x061	BYTE	NumberOfWaves
 	0x062	BYTE	Unknown1                 From Unknown5 in TIE, seems unused
-	0x063	BOOL	Unknown2
+	0x063	BOOL	StopArrivingWhen (enum)  Unknown2
 	0x064	BYTE	PlayerNumber
 	0x065	BYTE	ArriveOnlyIfHuman
 	0x066	BYTE	PlayerCraft
@@ -227,14 +227,7 @@ struct GoalFG (size 0x4E)
 	0x01	BYTE	Condition (enum)
 	0x02	BYTE	Amount (enum)
 	0x03	SBYTE	Points
-	0x04	BOOL	Enabled
-	0x05	BYTE	Team
-	0x06	BOOL	Unknown10
-	0x07	BOOL	Unknown11
-	0x08	BOOL	Unknown12
-	0x0B	BYTE	Unknown13
-	0x0C	BOOL	Unknown14
-	0x0D	BYTE	Reserved (0)			Unknown15
+	0x04	BOOL[10]	EnabledForTeam		Unknown10 through Unknown15
 	0x0E	BYTE	TimeLimit				Seconds * 5
 }
 
@@ -415,6 +408,11 @@ ArriveOnlyIfHuman, which is a boolean value that as its name suggests, when
 active will prevent a Flight Group from appearing in the mission if there isn't
 a human pilot behind the controls. PlayerCraft works the same as TIE, with
 00 being the default and 01 starting at position 2.
+
+StopArrivingWhen is a previously unknown value. It is a special condition that
+that is checked any time a new wave is supposed to spawn. If the condition is
+met, the wave will not spawn, and all remaining waves will be flagged as having
+come and gone. There are 4 possible values. See the enum listing.
 
 Yaw, Pitch and Roll values only work for Space Objects (mines, buoys, etc), and
 like TIE the flight engine automaticlly adds a -90° (nose down) pitch angle.
@@ -860,6 +858,12 @@ ArrivalDifficulty
 04	Medium, Hard
 05	Easy, Medium
 06	Never
+
+StopArrivingWhen
+00	No condition
+01	Any of this FG completes mission
+02	Team mission outcome is victory
+03	Team mission outcome is failure
 
 Condition
 00	Always (true)

--- a/Xvt/FlightGroup.Goal.cs
+++ b/Xvt/FlightGroup.Goal.cs
@@ -115,52 +115,23 @@ namespace Idmr.Platform.Xvt
 				get { return (short)((sbyte)_items[3] * 250); }
 				set { _items[3] = (byte)((value > 31750 ? 31750 : (value < -32000 ? -32000 : value)) / 250); }
 			}
-			/// <summary>Gets or sets if the Goal is active</summary>
-			public bool Enabled
+
+			/// <summary>Gets whether the goal is enabled for the specified team.</summary>
+			/// <remarks>The EnabledForTeam array encompasses 10 elements ranging from offsets 0x4 to 0xD, which formerly contained Unknown10 through Unknown 15.</remarks>
+			/// <exception cref="ArgumentOutOfRangeException">Team index is outside the bounds of the array.</exception>
+			public bool GetEnabledForTeam(int index)
 			{
-				get { return Convert.ToBoolean(_items[4]); }
-				set { _items[4] = Convert.ToByte(value); }
+				if(index < 0 || index >= 10)
+					throw new ArgumentOutOfRangeException("Team index must be 0 to 9, inclusive.");
+				return (_items[4 + index] != 0);
 			}
-			/// <summary>Gets or sets which Team the Goal applies to</summary>
-			public byte Team
+			/// <summary>Sets whether the goal is enabled for the specified team.</summary>
+			/// <exception cref="ArgumentOutOfRangeException">Team index is outside the bounds of the array.</exception>
+			public void SetEnabledForTeam(int index, bool state)
 			{
-				get { return _items[5]; }
-				set { _items[5] = value; }
-			}
-			/// <summary>Unknown value</summary>
-			/// <remarks>Goal offset 0x06</remarks>
-			public bool Unknown10
-			{
-				get { return Convert.ToBoolean(_items[6]); }
-				set { _items[6] = Convert.ToByte(value); }
-			}
-			/// <summary>Unknown value</summary>
-			/// <remarks>Goal offset 0x07</remarks>
-			public bool Unknown11
-			{
-				get { return Convert.ToBoolean(_items[7]); }
-				set { _items[7] = Convert.ToByte(value); }
-			}
-			/// <summary>Unknown value</summary>
-			/// <remarks>Goal offset 0x08</remarks>
-			public bool Unknown12
-			{
-				get { return Convert.ToBoolean(_items[8]); }
-				set { _items[8] = Convert.ToByte(value); }
-			}
-			/// <summary>Unknown value</summary>
-			/// <remarks>Goal offset 0x0B</remarks>
-			public byte Unknown13
-			{
-				get { return _items[11]; }
-				set { _items[11] = value; }
-			}
-			/// <summary>Unknown value</summary>
-			/// <remarks>Goal offset 0x0C</remarks>
-			public bool Unknown14
-			{
-				get { return Convert.ToBoolean(_items[12]); }
-				set { _items[12] = Convert.ToByte(value); }
+				if(index < 0 || index >= 10)
+					throw new ArgumentOutOfRangeException("Team index must be 0 to 9, inclusive.");
+				_items[4 + index] = Convert.ToByte(state);
 			}
 			/// <summary>Time limit</summary>
 			/// <remarks>Time limit that goal must be finished within (seconds*5).  Previously Unknown16. Goal offset 0x0E</remarks>

--- a/Xvt/FlightGroup.cs
+++ b/Xvt/FlightGroup.cs
@@ -257,14 +257,14 @@ namespace Idmr.Platform.Xvt
 		public byte Status2 { get; set; }
 		/// <summary>The additional grouping assignment, can share craft numbering</summary>
 		public byte GlobalUnit { get; set; }
-        /// <summary>Prevents craft numbering (if multiple craft in each wave) from appearing in the CMD.</summary>
-        public bool PreventCraftNumbering { get; set; }
-        /// <summary>If nonzero, the craft will abort mission when the elapsed mission time (player's in-flight clock) reaches this time in minutes.  Formerly Unknown20 at Offset 0x0521.</summary>
-        public byte DepartureClockMinutes { get; set; }
-        /// <summary>If nonzero, the craft will abort mission when the elapsed mission time (player's in-flight clock) reaches this time in seconds.  Formerly Unknown21 at Offset 0x0522.</summary>
-        public byte DepartureClockSeconds { get; set; }
 		/// <summary>Determines a special condition when additional waves will stop arriving. This is not an abort condition.</summary>
 		public byte StopArrivingWhen { get; set; }
+		/// <summary>Prevents craft numbering (if multiple craft in each wave) from appearing in the CMD.</summary>
+		public bool PreventCraftNumbering { get; set; }
+		/// <summary>If nonzero, the craft will abort mission when the elapsed mission time (player's in-flight clock) reaches this time in minutes.  Formerly Unknown20 at Offset 0x0521.</summary>
+		public byte DepartureClockMinutes { get; set; }
+		/// <summary>If nonzero, the craft will abort mission when the elapsed mission time (player's in-flight clock) reaches this time in seconds.  Formerly Unknown21 at Offset 0x0522.</summary>
+		public byte DepartureClockSeconds { get; set; }
 		/// <summary>Determines additional arrival delay time (minutes) based on whether Randomize is enabled in-game.</summary>
 		public byte RandomArrivalDelayMinutes { get; set; }
 		/// <summary>Determines additional arrival delay time (seconds) based on whether Randomize is enabled in-game.</summary>
@@ -325,16 +325,16 @@ namespace Idmr.Platform.Xvt
 			/// <remarks>Offset 0x0518, in Unknowns/Options section</remarks>
 			public bool Unknown18 { get; set; }
 			
-			// <summary>Previously Unknown value</summary>
-            // <remarks>Offset 0x0520, in Unknowns/Options section.  See PreventCraftNumbering.</remarks>
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0520, in Unknowns/Options section. See <see cref="PreventCraftNumbering"/></remarks>
 			//public bool Unknown19 { get; set; }
 
-            // <summary>Previously Unknown value</summary>
-            // <remarks>Offset 0x0521, in Unknowns/Options section.  See DepClockMinutes.</remarks>
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0521, in Unknowns/Options section. See <see cref="DepartureClockMinutes"/></remarks>
 			//public byte Unknown20 { get; set; }
 
-            // <summary>Previously Unknown value</summary>
-            // <remarks>Offset 0x0522, in Unknowns/Options section.  See DepClockSeconds.</remarks>
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0522, in Unknowns/Options section. See <see cref="DepartureClockSeconds"/></remarks>
 			//public byte Unknown21 { get; set; }
 			
 			/// <summary>Unknown value</summary>

--- a/Xvt/FlightGroup.cs
+++ b/Xvt/FlightGroup.cs
@@ -301,16 +301,16 @@ namespace Idmr.Platform.Xvt
 			/// <remarks>Offset 0x0062, in Craft section</remarks>
 			public byte Unknown1 { get; set; }
 			
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0063, in Craft section. <see cref="StopArrivingWhen"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0063, in Craft section. <see cref="StopArrivingWhen"/></remarks>
 			//public bool Unknown2 { get; set; }
 			
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0085, in Arr/Dep section. <see cref="RandomArrivalDelayMinutes"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0085, in Arr/Dep section. <see cref="RandomArrivalDelayMinutes"/></remarks>
 			//public byte Unknown3 { get; set; }
 			
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0096, in Arr/Dep section. <see cref="RandomArrivalDelaySeconds"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0096, in Arr/Dep section. <see cref="RandomArrivalDelaySeconds"/></remarks>
 			//public byte Unknown4 { get; set; }
 			
 			/// <summary>Unknown value</summary>
@@ -325,16 +325,16 @@ namespace Idmr.Platform.Xvt
 			/// <remarks>Offset 0x0518, in Unknowns/Options section</remarks>
 			public bool Unknown18 { get; set; }
 			
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0520, in Unknowns/Options section. See <see cref="PreventCraftNumbering"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0520, in Unknowns/Options section. See <see cref="PreventCraftNumbering"/></remarks>
 			//public bool Unknown19 { get; set; }
 
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0521, in Unknowns/Options section. See <see cref="DepartureClockMinutes"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0521, in Unknowns/Options section. See <see cref="DepartureClockMinutes"/></remarks>
 			//public byte Unknown20 { get; set; }
 
-			/// <summary>Previously Unknown value</summary>
-			/// <remarks>Offset 0x0522, in Unknowns/Options section. See <see cref="DepartureClockSeconds"/></remarks>
+			// <summary>Previously Unknown value</summary>
+			// <remarks>Offset 0x0522, in Unknowns/Options section. See <see cref="DepartureClockSeconds"/></remarks>
 			//public byte Unknown21 { get; set; }
 			
 			/// <summary>Unknown value</summary>

--- a/Xvt/FlightGroup.cs
+++ b/Xvt/FlightGroup.cs
@@ -263,6 +263,12 @@ namespace Idmr.Platform.Xvt
         public byte DepartureClockMinutes { get; set; }
         /// <summary>If nonzero, the craft will abort mission when the elapsed mission time (player's in-flight clock) reaches this time in seconds.  Formerly Unknown21 at Offset 0x0522.</summary>
         public byte DepartureClockSeconds { get; set; }
+		/// <summary>Determines a special condition when additional waves will stop arriving. This is not an abort condition.</summary>
+		public byte StopArrivingWhen { get; set; }
+		/// <summary>Determines additional arrival delay time (minutes) based on whether Randomize is enabled in-game.</summary>
+		public byte RandomArrivalDelayMinutes { get; set; }
+		/// <summary>Determines additional arrival delay time (seconds) based on whether Randomize is enabled in-game.</summary>
+		public byte RandomArrivalDelaySeconds { get; set; }
 
         /// <summary>Gets the array of alternate weapons the player can select</summary>
 		/// <remarks>Use <see cref="LoadoutIndexer.Indexes"/> for indexes</remarks>
@@ -295,17 +301,17 @@ namespace Idmr.Platform.Xvt
 			/// <remarks>Offset 0x0062, in Craft section</remarks>
 			public byte Unknown1 { get; set; }
 			
-			/// <summary>Unknown value</summary>
-			/// <remarks>Offset 0x0063, in Craft section</remarks>
-			public bool Unknown2 { get; set; }
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0063, in Craft section. <see cref="StopArrivingWhen"/></remarks>
+			//public bool Unknown2 { get; set; }
 			
-			/// <summary>Unknown value</summary>
-			/// <remarks>Offset 0x0085, in Arr/Dep section, may be ArrDelay30Sec</remarks>
-			public byte Unknown3 { get; set; }
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0085, in Arr/Dep section. <see cref="RandomArrivalDelayMinutes"/></remarks>
+			//public byte Unknown3 { get; set; }
 			
-			/// <summary>Unknown value</summary>
-			/// <remarks>Offset 0x0096, in Arr/Dep section</remarks>
-			public byte Unknown4 { get; set; }
+			/// <summary>Previously Unknown value</summary>
+			/// <remarks>Offset 0x0096, in Arr/Dep section. <see cref="RandomArrivalDelaySeconds"/></remarks>
+			//public byte Unknown4 { get; set; }
 			
 			/// <summary>Unknown value</summary>
 			/// <remarks>Offset 0x0098, in Arr/Dep section</remarks>

--- a/Xvt/Mission.cs
+++ b/Xvt/Mission.cs
@@ -150,6 +150,7 @@ namespace Idmr.Platform.Xvt
 			Unknown1 = br.ReadByte();
 			stream.Position++;
 			Unknown2 = br.ReadByte();
+			RndSeed = br.ReadByte();
 			stream.Position = 0xB;
 			Unknown3 = Convert.ToBoolean(br.ReadByte());
 			stream.Position = 0x14;
@@ -510,7 +511,8 @@ namespace Idmr.Platform.Xvt
 				bw.Write((short)FlightGroups.Count);
 				bw.Write((short)Messages.Count);
 				bw.Write((short)Unknown1);
-				bw.Write((short)Unknown2);
+				bw.Write(Unknown2);
+				bw.Write(RndSeed);
 				fs.Position++;
 				bw.Write(Unknown3);
 				fs.Position = 0x14;
@@ -988,6 +990,9 @@ namespace Idmr.Platform.Xvt
 		/// <summary>Unknown FileHeader value</summary>
 		/// <remarks>Offset = 0x08</remarks>
 		public byte Unknown2 { get; set; }
+		/// <summary>Seeds the random number generator that is responsible for deciding backdrops and asteroid positions.</summary>
+		/// <remarks>Offset = 0x09</remarks>
+		public byte RndSeed { get; set; }
 		/// <summary>Unknown FileHeader value</summary>
 		/// <remarks>Offset = 0x0B</remarks>
 		public bool Unknown3 { get; set; }

--- a/Xvt/Mission.cs
+++ b/Xvt/Mission.cs
@@ -632,16 +632,9 @@ namespace Idmr.Platform.Xvt
 						fs.WriteByte(FlightGroups[i].Goals[j].Condition);
 						fs.WriteByte(FlightGroups[i].Goals[j].Amount);
 						bw.Write(FlightGroups[i].Goals[j].RawPoints);
-						bw.Write(FlightGroups[i].Goals[j].Enabled);
-						fs.WriteByte(FlightGroups[i].Goals[j].Team);
-						bw.Write(FlightGroups[i].Goals[j].Unknown10);
-						bw.Write(FlightGroups[i].Goals[j].Unknown11);
-						bw.Write(FlightGroups[i].Goals[j].Unknown12);
-						fs.Position += 2;	//[JB]
-						fs.WriteByte(FlightGroups[i].Goals[j].Unknown13);
-						bw.Write(FlightGroups[i].Goals[j].Unknown14);
-						fs.Position++;
-						fs.WriteByte(FlightGroups[i].Goals[j].TimeLimit);  //[JB] Previously Unknown16
+						for (int k = 0; k < 10; k++)
+							bw.Write(FlightGroups[i].Goals[j].GetEnabledForTeam(k));
+						fs.WriteByte(FlightGroups[i].Goals[j].TimeLimit);
 						fs.Position = p + 0x243 + (j*0x4E);
 					}
 					fs.Position++;

--- a/Xvt/Mission.cs
+++ b/Xvt/Mission.cs
@@ -196,7 +196,7 @@ namespace Idmr.Platform.Xvt
 				FlightGroups[i].FormLeaderDist = buffer[0x10];
 				FlightGroups[i].NumberOfWaves = (byte)(buffer[0x11]+1);
 				FlightGroups[i].Unknowns.Unknown1 = buffer[0x12];
-				FlightGroups[i].Unknowns.Unknown2 = Convert.ToBoolean(buffer[0x13]);
+				FlightGroups[i].StopArrivingWhen = (buffer[0x13]);
 				FlightGroups[i].PlayerNumber = buffer[0x14];
 				FlightGroups[i].ArriveOnlyIfHuman = Convert.ToBoolean(buffer[0x15]);
 				FlightGroups[i].PlayerCraft = buffer[0x16];
@@ -221,14 +221,14 @@ namespace Idmr.Platform.Xvt
 				FlightGroups[i].ArrDepAO[0] = Convert.ToBoolean(buffer[0xB]);
 				FlightGroups[i].ArrDepAO[1] = Convert.ToBoolean(buffer[0x16]);
 				FlightGroups[i].ArrDepAO[2] = Convert.ToBoolean(buffer[0x17]);
-				FlightGroups[i].Unknowns.Unknown3 = buffer[0x18];
+				FlightGroups[i].RandomArrivalDelayMinutes = buffer[0x18];
 				FlightGroups[i].ArrivalDelayMinutes = buffer[0x19];
 				FlightGroups[i].ArrivalDelaySeconds = buffer[0x1A];
 				FlightGroups[i].ArrDepAO[3] = Convert.ToBoolean(buffer[0x25]);
 				FlightGroups[i].DepartureTimerMinutes = buffer[0x26];
 				FlightGroups[i].DepartureTimerSeconds = buffer[0x27];
 				FlightGroups[i].AbortTrigger = buffer[0x28];
-				FlightGroups[i].Unknowns.Unknown4 = buffer[0x29];
+				FlightGroups[i].RandomArrivalDelaySeconds = buffer[0x29];
 				FlightGroups[i].Unknowns.Unknown5 = buffer[0x2B];
 				FlightGroups[i].ArrivalCraft1 = buffer[0x2D];
 				FlightGroups[i].ArrivalMethod1 = Convert.ToBoolean(buffer[0x2E]);	// false = hyper, true = mothership
@@ -569,7 +569,7 @@ namespace Idmr.Platform.Xvt
 					fs.WriteByte(FlightGroups[i].FormLeaderDist);
 					fs.WriteByte((byte)(FlightGroups[i].NumberOfWaves-1));
 					fs.WriteByte(FlightGroups[i].Unknowns.Unknown1);
-					bw.Write(FlightGroups[i].Unknowns.Unknown2);
+					bw.Write(FlightGroups[i].StopArrivingWhen);
 					fs.WriteByte(FlightGroups[i].PlayerNumber);
 					bw.Write(FlightGroups[i].ArriveOnlyIfHuman);
 					fs.WriteByte(FlightGroups[i].PlayerCraft);
@@ -589,7 +589,7 @@ namespace Idmr.Platform.Xvt
 					fs.Position += 2;
 					bw.Write(FlightGroups[i].ArrDepAO[1]);
 					bw.Write(FlightGroups[i].ArrDepAO[2]);
-					fs.WriteByte(FlightGroups[i].Unknowns.Unknown3);
+					fs.WriteByte(FlightGroups[i].RandomArrivalDelayMinutes);
 					fs.WriteByte(FlightGroups[i].ArrivalDelayMinutes);
 					fs.WriteByte(FlightGroups[i].ArrivalDelaySeconds);
 					for (j = 0; j < 4; j++) fs.WriteByte(FlightGroups[i].ArrDepTriggers[4][j]);
@@ -599,7 +599,7 @@ namespace Idmr.Platform.Xvt
 					fs.WriteByte(FlightGroups[i].DepartureTimerMinutes);
 					fs.WriteByte(FlightGroups[i].DepartureTimerSeconds);
 					fs.WriteByte(FlightGroups[i].AbortTrigger);
-					fs.WriteByte(FlightGroups[i].Unknowns.Unknown4);
+					fs.WriteByte(FlightGroups[i].RandomArrivalDelaySeconds);
 					fs.Position++;
 					fs.WriteByte(FlightGroups[i].Unknowns.Unknown5);
 					fs.Position++;

--- a/Xvt/Strings.cs
+++ b/Xvt/Strings.cs
@@ -556,6 +556,12 @@ namespace Idmr.Platform.Xvt
 										"Stationary, 100% Systems, does not return fire.|Meaningless|Meaningless",
 										"Stationary, 100% Systems, does not return fire.|Meaningless|Meaningless"
 									};
+
+		static readonly string[] _stopArrivingWhen = { "No condition (normal)",
+												"Any of this FG completes mission",
+												"Team mission outcome is victory",
+												"Team mission outcome is failure"
+									};
         #endregion
 
 		/// <summary>Replaces <see cref="CraftType"/> and <see cref="CraftAbbrv"/> with custom arrays, or restores defaults.</summary>
@@ -635,5 +641,8 @@ namespace Idmr.Platform.Xvt
 		/// <summary>Gets of copy of the descriptions of orders and variables</summary>
 		/// <remarks>Array is Length = 40</remarks>
 		public static string[] OrderDesc { get { return (string[])_orderDesc.Clone(); } }
+		/// <summary>Gets of copy of the StopArrivingWhen enum used in arr/dep</summary>
+		/// <remarks>Array is Length = 4</remarks>
+		public static string[] StopArrivingWhen { get { return (string[])_stopArrivingWhen.Clone(); } }
 	}
 }

--- a/Xvt/Strings.cs
+++ b/Xvt/Strings.cs
@@ -369,7 +369,7 @@ namespace Idmr.Platform.Xvt
 										"be dropped off",
 										"* be destroyed in one hit",
 										"NOT be disabled",
-										"NOT be picked up",
+										"NOT be captured",
 										"come and go w/o inspection",
 										"begin being boarded",       //was "be docked with"
 										"NOT being boarded",
@@ -385,7 +385,7 @@ namespace Idmr.Platform.Xvt
 										"be all Player Craft",
 										"be all AI Craft",
 										"come and go",
-										"be picked up",
+										"be bagged",
 										"withdraw",
 										"be carried away"
 								  };
@@ -413,7 +413,7 @@ namespace Idmr.Platform.Xvt
 											"All teams except",
 											"* All players except #",
 											"Global Unit",
-                                            "All global units except"
+											"All global units except"
 									  };
 		static readonly string[] _amount = { "100%",
 									"75%",
@@ -588,10 +588,10 @@ namespace Idmr.Platform.Xvt
 		static readonly public string TeamPrefixes = "1234AFH";
 
 		/// <summary>Gets a copy of Arrival difficulty settings</summary>
-		/// <remarks>Array has a Length of 10</remarks>
+		/// <remarks>Array has a Length of 11</remarks>
 		new public static string[] Difficulty { get { return (string[])_difficulty.Clone(); } }
         /// <summary>Gets a copy of Arrival Difficulty abbreviations</summary>
-        /// <remarks>Array has a Length of 10</remarks>
+        /// <remarks>Array has a Length of 11</remarks>
         new public static string[] DifficultyAbbrv { get { return (string[])_difficultyAbbrv.Clone(); } }
         /// <summary>Gets a copy of the default team name entries that craft roles can be applied to.</summary>
         /// <remarks>Array is Length = 8</remarks>
@@ -633,7 +633,7 @@ namespace Idmr.Platform.Xvt
 		/// <remarks>Array is Length = 40</remarks>
 		public static string[] Orders { get { return (string[])_orders.Clone(); } }
 		/// <summary>Gets of copy of the craft behaviours to be used in triggers</summary>
-		/// <remarks>Array is Length = 22</remarks>
+		/// <remarks>Array is Length = 26</remarks>
 		public static string[] CraftWhen { get { return (string[])_craftWhen.Clone(); } }
 		/// <summary>Gets of copy of the individual craft abort conditions</summary>
 		/// <remarks>Array is Length = 10</remarks>

--- a/Xwa/FlightGroup.Order.cs
+++ b/Xwa/FlightGroup.Order.cs
@@ -131,7 +131,7 @@ namespace Idmr.Platform.Xwa
 						s = "Craft when " + BaseStrings.SafeString(Strings.CraftWhen, target);
 						break;
 					case 8:
-						s = "Global Group " + target;
+						s = "GG:" + target;
 						break;
                     case 9:
                         s = "Rating " + BaseStrings.SafeString(Strings.Rating, target);
@@ -167,7 +167,7 @@ namespace Idmr.Platform.Xwa
                         s = "Not IFF " + BaseStrings.SafeString(Strings.IFF, target);
                         break;
                     case 20:
-                        s = "Not GG " + target;
+                        s = "Not GG:" + target;
                         break;
                     case 21:
                         s = "All Teams except TM:" + target;

--- a/Xwa/Mission.Trigger.cs
+++ b/Xwa/Mission.Trigger.cs
@@ -132,7 +132,7 @@ namespace Idmr.Platform.Xwa
 							trig += "Craft When " + BaseStrings.SafeString(Strings.CraftWhen, Variable);
 							break;
 						case 8:
-							trig += "Global Group " + Variable;
+							trig += "GG:" + Variable;
 							break;
                         case 9:
                             trig += "Rating " + BaseStrings.SafeString(Strings.Rating, Variable);
@@ -166,7 +166,7 @@ namespace Idmr.Platform.Xwa
                             trig += "all except IFF:" + Variable;
 							break;
                         case 20:
-                            trig += "all except GG " + Variable;
+                            trig += "all except GG:" + Variable;
                             break;
                         case 21:
                             trig += "all except TM:" + Variable;


### PR DESCRIPTION
With these changes, the XvT platform is mostly feature complete.  Remaining unknowns seem to be legacy values left over from TIE Fighter, or completely unused.  After consulting research and receiving feedback, also corrected some trigger strings that I had previously misnamed.
XWA modified so that YOGEME can utilize the GlobalGroup names for descriptive purposes, as per a feature request.
XvT platform documentation for trigger conditions has been reorganized and updated