### PR TITLE
Trigger text updates

### DIFF
--- a/Tie/FlightGroup.Order.cs
+++ b/Tie/FlightGroup.Order.cs
@@ -143,7 +143,7 @@ namespace Idmr.Platform.Tie
 			{
 				if (Command == 0) return "None";
 				string order = BaseStrings.SafeString(Strings.Orders, Command);
-				if ((Command >= 7 && Command <= 0x12) || (Command >= 0x17 && Command <= 0x1B) || Command == 0x1F || Command == 0x20 || Command == 0x25)	//all orders where targets are important
+				if ((Command >= 7 && Command <= 0x12) || (Command >= 0x15 && Command <= 0x1B) || Command == 0x1F || Command == 0x20 || Command == 0x25)	//all orders where targets are important
 				{
 					string s = orderTargetString(Target1, Target1Type);
 					string s2 = orderTargetString(Target2, Target2Type);

--- a/Xvt/FlightGroup.Order.cs
+++ b/Xvt/FlightGroup.Order.cs
@@ -199,7 +199,7 @@ namespace Idmr.Platform.Xvt
 			{
 				if (Command == 0) return "None";
 				string order = BaseStrings.SafeString(Strings.Orders, Command);
-				if ((Command >= 7 && Command <= 0x12) || (Command >= 0x17 && Command <= 0x1B) || Command == 0x1F || Command == 0x20 || Command == 0x25)	//all orders where targets are important
+				if ((Command >= 7 && Command <= 0x12) || (Command >= 0x15 && Command <= 0x1B) || Command == 0x1F || Command == 0x20 || Command == 0x25)	//all orders where targets are important
 				{
 					string s = orderTargetString(Target1, Target1Type);
 					string s2 = orderTargetString(Target2, Target2Type);

--- a/Xwa/FlightGroup.Order.cs
+++ b/Xwa/FlightGroup.Order.cs
@@ -225,6 +225,10 @@ namespace Idmr.Platform.Xwa
 						else order += " if " + s2;
 					}
 				}
+				else if (Command == 50)  // Hyper to Region
+				{
+					order += " REG:" + this.Variable1;
+				}
 				return order;
 			}
 

--- a/Xwa/FlightGroup.Order.cs
+++ b/Xwa/FlightGroup.Order.cs
@@ -206,7 +206,7 @@ namespace Idmr.Platform.Xwa
 			{
 				if (Command == 0) return "None";
 				string order = BaseStrings.SafeString(Strings.Orders, Command);
-				if ((Command >= 7 && Command <= 18) || (Command >= 23 && Command <= 27) || Command == 31 || Command == 32 || Command == 37)	//all orders where targets are important
+				if ((Command >= 7 && Command <= 18) || (Command >= 21 && Command <= 27) || Command == 31 || Command == 32 || Command == 37) //all orders where targets are important
 				{
 					string s = orderTargetString(Target1, Target1Type);
 					string s2 = orderTargetString(Target2, Target2Type);

--- a/Xwa/FlightGroup.Order.cs
+++ b/Xwa/FlightGroup.Order.cs
@@ -115,7 +115,7 @@ namespace Idmr.Platform.Xwa
 						s = "FG:" + target;
 						break;
 					case 2:
-						s = BaseStrings.SafeString(Strings.CraftType, target + 1) + "s";
+						s = BaseStrings.SafeString(Strings.CraftType, target) + "s";
 						break;
 					case 3:
 						s = BaseStrings.SafeString(Strings.ShipClass, target);
@@ -157,7 +157,7 @@ namespace Idmr.Platform.Xwa
                         s = "Not FG:" + target;
                         break;
                     case 16:
-                        s = "Not ship type " + BaseStrings.SafeString(Strings.CraftType, target + 1);
+                        s = "Not ship type " + BaseStrings.SafeString(Strings.CraftType, target);
                         break;
                     case 17:
                         s = "Not ship class " + BaseStrings.SafeString(Strings.ShipClass, target);

--- a/Xwa/Mission.Trigger.cs
+++ b/Xwa/Mission.Trigger.cs
@@ -116,7 +116,7 @@ namespace Idmr.Platform.Xwa
 							trig += "FG:" + Variable;
 							break;
 						case 2:
-							trig += "Ship type " + BaseStrings.SafeString(Strings.CraftType, Variable + 1);
+							trig += "Ship type " + BaseStrings.SafeString(Strings.CraftType, Variable);
 							break;
 						case 3:
 							trig += "Ship class " + BaseStrings.SafeString(Strings.ShipClass, Variable);
@@ -156,7 +156,7 @@ namespace Idmr.Platform.Xwa
                             trig += "all except FG:" + Variable;
                             break;
                         case 16:
-                            trig += "all except " + BaseStrings.SafeString(Strings.CraftType, Variable + 1) + "s";
+                            trig += "all except " + BaseStrings.SafeString(Strings.CraftType, Variable) + "s";
                             break;
                         case 17:
                             trig += "all except " + BaseStrings.SafeString(Strings.ShipClass, Variable);


### PR DESCRIPTION
For XWA, fixed an off-by-one issue with the trigger ShipType lists (see the corresponding YOGEME pull request).  I may have inadvertently caused this bug, long ago. Apparently XWA is unique in that it requires a null entry in the list. TIE and XvT do not.

Modified the output text for the "Hyper to Region" order, so that YOGEME can resolve the tag into a descriptive region number and name.

Also for TIE, XvT, and XWA, the "SS Patrol Waypoints" and "SS Await Return" orders use their target lists for firing purposes.  These orders are now included to provide target information in the output strings.