### PR TITLE
Copy constructors for XvT multi-select editing

### DIFF
--- a/Xvt/FlightGroup.Goal.cs
+++ b/Xvt/FlightGroup.Goal.cs
@@ -44,6 +44,20 @@ namespace Idmr.Platform.Xvt
 				_items = new byte[15];
 				_items[1] = 10;
 			}
+			/// <summary>Constructs a new Goal from an existing Goal. If null, a blank Goal is created.</summary>
+			/// <remarks><see cref="Condition"/> is set to <b>10</b> ("never (FALSE)")</remarks>
+			public Goal(Goal other)
+			{
+				_items = new byte[15];
+				_items[1] = 10;
+				if (other != null)
+				{
+					Array.Copy(other._items, _items, _items.Length);
+					_incompleteText = other._incompleteText;
+					_completeText = other._completeText;
+					_failedText = other._failedText;
+				}
+			}
 			
 			/// <summary>Initlialize a new Goal from raw data</summary>
 			/// <param name="raw">Raw byte data, minimum Length of 15</param>

--- a/Xvt/FlightGroup.Order.cs
+++ b/Xvt/FlightGroup.Order.cs
@@ -43,6 +43,19 @@ namespace Idmr.Platform.Xvt
 				_items[1] = 10;	// Throttle
 				_items[10] = _items[16] = 1;	// AndOrs
 			}
+			/// <summary>Constructs a new Order from an existing Order. If null, a blank Order is created.</summary>
+			/// <remarks><see cref="BaseFlightGroup.BaseOrder.Throttle"/> set to <b>100%</b>, AndOr values set to <b>"Or"</b></remarks>
+			public Order(Order other)
+			{
+				_items = new byte[19];
+				_items[1] = 10;	// Throttle
+				_items[10] = _items[16] = 1;    // AndOrs
+				if (other != null)
+				{
+					Array.Copy(other._items, _items, _items.Length);
+					_designation = other._designation;
+				}
+			}
 			
 			/// <summary>Initlializes a new Order from raw data</summary>
 			/// <remarks>If <i>raw</i>.Length is 19 or greater, reads 19 bytes. Otherwise reads 18 bytes.</remarks>

--- a/Xvt/Mission.Trigger.cs
+++ b/Xvt/Mission.Trigger.cs
@@ -32,6 +32,14 @@ namespace Idmr.Platform.Xvt
 			/// <summary>Initializes a blank Trigger</summary>
 			public Trigger() : base(new byte[4]) { }
 
+			/// <summary>Constructs a new Trigger from an existing Trigger. If null, a blank Trigger is created.</summary>
+			public Trigger(Trigger other)
+			{
+				_items = new byte[4];
+				if (other != null)
+					Array.Copy(other._items, _items, _items.Length);
+			}
+
 			/// <summary>Initializes a new Trigger from raw data</summary>
 			/// <param name="raw">Raw data, minimum Length of 4</param>
 			/// <exception cref="ArgumentException">Invalid <paramref name="raw"/>.Length value<br/><b>-or-</b><br/>Invalid member values</exception>


### PR DESCRIPTION
During a multi-select edit, pasting certain objects (triggers, orders, and FG goals) needs to be new unique object for each flightgroup that receives it.