### PR TITLE
X-Wing platform upgrade for Briefing V2

### DIFF
--- a/BaseBriefing.cs
+++ b/BaseBriefing.cs
@@ -50,7 +50,7 @@ namespace Idmr.Platform
 		{
 			/// <summary>No type defined.</summary>
 			None,
-			/// <summary>Creates breakpoint for briefing interface <b>Next</b> command (TIE/XvT only).</summary>
+			/// <summary>Creates breakpoint for briefing interface <b>Next</b>.</summary>
 			/// <remarks>Parameters:<br/>None</remarks>
 			SkipMarker,
 			/// <summary>Unknown.</summary>

--- a/Converter.cs
+++ b/Converter.cs
@@ -1518,10 +1518,10 @@ namespace Idmr.Platform
 			Dictionary<int, int> brfToReal = new Dictionary<int, int>();  //Maps BRF FlightGroups to their actual XWI FlightGroup, or a new dummy FG to be used as a briefing icon.
 
 			Xwing.BriefingPage pg = miss.Briefing.GetBriefingPage(0);
-			int cs = pg.CoordSet;
+			int ws = pg.Waypoint;
 			int wpIndex = (byte)Xwing.FlightGroup.WaypointIndex.Start1;
-			if (cs >= 1 && cs <= 3) //If not Start1, transform into the waypoint index of the virtualized coordinate
-				wpIndex = (byte)Xwing.FlightGroup.WaypointIndex.CS1 + cs - 1;
+			if (ws >= 1 && ws <= 3) //If not Start1, transform into the waypoint index of the virtualized briefing coordinate
+				wpIndex = (byte)Xwing.FlightGroup.WaypointIndex.Briefing1 + ws - 1;
 			for (int i = 0; i < miss.FlightGroupsBriefing.Count; i++)
 			{
 				Xwing.FlightGroup bfg = miss.FlightGroupsBriefing[i];
@@ -2012,10 +2012,10 @@ namespace Idmr.Platform
 			Dictionary<int, int> brfToReal = new Dictionary<int, int>();  //Maps BRF FlightGroups to their actual XWI FlightGroup, or a new dummy FG to be used as a briefing icon.
 
 			Xwing.BriefingPage pg = miss.Briefing.GetBriefingPage(0);
-			int cs = pg.CoordSet;
+			int ws = pg.Waypoint;
 			int wpIndex = 0; //Default to Start1
-			if (cs >= 1 && cs <= 3) //If not Start1, transform into the waypoint index of the virtualized coordinate
-				wpIndex = 7 + cs - 1;
+			if (ws >= 1 && ws <= 3) //If not Start1, transform into the waypoint index of the virtualized coordinate
+				wpIndex = 7 + ws - 1;
 			for (int i = 0; i < miss.FlightGroupsBriefing.Count; i++)
 			{
 				Xwing.FlightGroup bfg = miss.FlightGroupsBriefing[i];
@@ -2506,10 +2506,10 @@ namespace Idmr.Platform
 			}
 			Xwing.BriefingPage pg = miss.Briefing.GetBriefingPage(0);
 			xwa.Briefings[0].Length = xwa.Briefings[0].ConvertSecondsToTicks(miss.Briefing.ConvertTicksToSeconds(pg.Length));
-			int cs = pg.CoordSet;
+			int ws = pg.Waypoint;
 			int wpIndex = 0; //Default to Start1
-			if (cs >= 1 && cs <= 3) //If not Start1, transform into the waypoint index of the virtualized coordinate
-				wpIndex = 7 + cs - 1;
+			if (ws >= 1 && ws <= 3) //If not Start1, transform into the waypoint index of the virtualized coordinate
+				wpIndex = 7 + ws - 1;
 			for (short i = 0; i < miss.FlightGroupsBriefing.Count; i++)
 			{
 				Xwing.FlightGroup bfg = miss.FlightGroupsBriefing[i];

--- a/Mission_XWING95.txt
+++ b/Mission_XWING95.txt
@@ -60,7 +60,7 @@ struct FileHeader (size 0xCE)
 	0x002	SHORT	TimeLimitMinutes
 	0x004	SHORT	EndEvent (enum)
 	0x006	SHORT	RndSeed (unused)
-	0x008	SHORT	Location (enum)
+	0x008	SHORT	Location (bool)
 	0x00A	CHAR[3][64]	EndOfMissionMessages
 	0x0CA	SHORT	NumFGs
 	0x0CC	SHORT	NumOGs
@@ -120,9 +120,9 @@ struct ObjectGroup (size 0x46)
 
 --  BRF FILE FORMAT
 BriefingHeader
-Coordinate[CoordinateCount][IconCount]
+Waypoint[WaypointCount][IconCount]
 Icon[IconCount]
-WindowUISettings
+PageTemplates
 Pages
 MissionHeader
 IconExtraData
@@ -135,10 +135,10 @@ struct BriefingHeader (size 0x6)
 {
 	0x00	SHORT	PlatformID (2)
 	0x02	SHORT	IconCount
-	0x04	SHORT	CoordinateCount
+	0x04	SHORT	WaypointCount
 }
 
-struct Coordinate (size 0x6)
+struct Waypoint (size 0x6)
 {
 	0x00	SHORT	X
 	0x02	SHORT	Y
@@ -160,16 +160,16 @@ struct Icon (size 0x40)
 	0x3E	SHORT	Roll
 }
 
-WindowUISettings
+PageTemplates
 {
-	0x00	SHORT SettingsCount    (usually 2, but not always)
-	foreach(SettingsCount)
+	0x00	SHORT TemplateCount    (usually 2, but not always.  Max: 4)
+	foreach(TemplateCount)
 	{
-		ViewportSetting[5]
+		PagePanel[5]
 	}
 }
 
-struct ViewportSetting (size 0xA)
+struct PagePanel (size 0xA)
 {
 	0x00	SHORT	Top
 	0x02	SHORT	Left
@@ -180,12 +180,12 @@ struct ViewportSetting (size 0xA)
 
 Pages
 {
-	0x00	SHORT	PageCount
+	0x00	SHORT	PageCount   (Max: 8)
 	foreach(PageCount)
 	{
 		0x00	SHORT	Duration (ticks)
 		0x02	SHORT	EventsLength
-		0x04	SHORT	CoordinateSet
+		0x04	SHORT	Waypoint
 		0x06	SHORT	PageType
 		0x08	SHORT[]	Events[EventsLength]
 	}
@@ -196,7 +196,7 @@ struct MissionHeader (size 0xC8)
 	0x00	SHORT	TimeLimitMinutes
 	0x02	SHORT	EndEvent (enum)
 	0x04	SHORT	RndSeed (unused)
-	0x06	SHORT	Location (enum)
+	0x06	SHORT	Location (bool)
 	0x08	CHAR[3][64]	EndOfMissionMessages
 }
 
@@ -208,17 +208,25 @@ IconExtraData
 	}
 }
 
-struct Tag
+Tags
 {
-	0x0	SHORT	Length
-	0x2	CHAR[Length]
+	0x00	SHORT Count    (always 32, Max: 32)
+	foreach(Count)
+	{
+		0x0	SHORT	Length
+		0x2	CHAR[Length]
+	}
 }
 
-struct String
+Strings
 {
-	0x0	SHORT	Length
-	0x2	CHAR[Length] String
-		BYTE[Length] Highlight
+	0x00	SHORT Count    (always 32, Max: 32)
+	foreach(Count)
+	{
+		0x0	SHORT	Length
+		0x2	CHAR[Length] String
+			BYTE[Length] Highlight
+	}
 }
 
 =====
@@ -246,8 +254,8 @@ RndSeed is supposed to be an initializer to the pseudo-random number generator,
 for the purposes of randomizing backdrops. However, it is not actually used by
 the game and therefore completely useless. It is zero in all missions.
 
-Location (enum) determines whether mission is in deep space, or Death Star
-Surface.
+Location determines whether mission is in deep space (false), or Death Star
+Surface (true).
 
 EndOfMissionMessages
 Three messages that are displayed in sequence when the mission is complete.
@@ -354,8 +362,9 @@ Start 2
 Start 3
 Hyperspace
 
-Unlike other platforms, there is no Briefing waypoint.  Instead, it is stored
-in the briefing (BRF) file as a Coordinate Set.
+Unlike other platforms, there is no Briefing waypoint stored with the
+flightgroup.  Instead, it is stored in the briefing (BRF) file as a
+simplified coordinate.
 
 Formation (enum)
 Determines the flight formation, if there are multiple craft in the wave.
@@ -448,50 +457,66 @@ on, or use any information from the XWI file.
 The BRF file structure is heavily dynamic, as nearly every section is variable
 length.
 
-There is a short header defining how many CoordinateSet and IconSet are
-present.
+There is a short header defining how many Waypoints and Icons are present.
 
-CoordinateSet are essentially waypoints.  Typical LEC missions have two
-CoordinateSet, the first a duplicate of the XWI starting point, and the second
-for the briefing map.  Waypoint units are identical to craft waypoints
-(160 = 1 km).
+Briefing waypoints are slightly different from flightgroup waypoints.  There is
+no value to determine whether the waypoint is enabled, just the coordinate
+itself.  Typical LEC missions have two Waypoints, the first a duplicate of the
+XWI starting point, and the second for the briefing map.  Waypoint positions 
+are identical to craft waypoints (160 = 1 km).
 Note: The starting point's Y axis is usually inverted from the XWI's Y axis.
 
-IconSet holds the craft information for the icons displayed on the briefing
-map.  This section shares much similarity to the FlightGroup and ObjectGroup in
-the XWI file, but exists independently of them.  These can be considered as
+Icons holds the craft information for the icons displayed on the briefing map.
+This section shares much similarity to the FlightGroup and ObjectGroup in the
+XWI file, but exists independently of them.  These can be considered as
 Briefing-only FlightGroups.  They are sometimes identical to the XWI file, but
 there is no guarantee.  The number of FlightGroups may differ between the XWI
 and BRF files, as well as their ordering.
 Note: While the XWI file does not have a CraftType for the B-Wing (Y-Wing with
 a special status) the BRF file DOES have a specific icon for the B-Wing.
 
-WindowUISettings is a unique section to the XWING briefing which determines the
-coordinate viewports of each element on screen.  There are five elements:
-Title text, caption text, Unused1, Unused2, and briefing map, in that order.
-Each element has five SHORTs.  Four defining the rectangle coordinates of the
-top, left, bottom, and right edges.  The final SHORT is a boolean that
-determines whether the element is visible.
+PageTemplates is a unique section to the XWING briefing which determines the
+coordinate viewports of each panel element on screen.  The section begins with
+the number of templates.  LEC convention is typically two templates, one for
+the map, another for text, in that order.  There is a maximum of four possible
+templates.
 
-Unlike other platforms, the briefing is divided into Pages.  Each page is
-either a "Map page" to render a briefing map, or a "Text page" to render text.
+Each template contains five panels: Title text, caption text, Panel3, Panel4,
+and map, in that order.
 
-Note: The page is actually a WindowUISettings index that determines whether
-the page renders map or text viewports, but the format described applies to
-the convention commonly seen in LEC's own files.
+Each panel has five SHORTs.  Four defining the rectangle pixel coordinates of
+the top, left, bottom, and right edges.  Left and right typically range from 0
+to 212.  Top and bottom typically range from 0 to 138.  The final SHORT is a
+boolean that determines whether the element is visible.
 
-The command listing itself I'll leave for the list definition, that'll also
-have the variable listing as well. The first value is the duration of the
-briefing itself in ticks.  XWING uses 0x8 ticks per second.
+Panel3 and Panel4 are typically unused, with the rectangle coordinates and
+visibility all set to zeroes.  However they can be activated.  Each panel type
+has its own dedicated caption event to display a string.
+
+After the page templates and panel settings are the actual pages.  Each page
+uses one of the previously defined templates, a "Map page" to render a briefing
+map, or a "Text page" to render text.
+
+The page section begins with the number of pages.  LEC convention is a minimum
+of two pages.  The map is always first, followed by one or more text pages.
+There is a maximum of eight pages.
+
+The first value in each page is the duration of the briefing itself in ticks.
+XWING is approximately 9 or 10 ticks per second, depending on game version.
+The 1998 Special Edition is slower.
+
+EventsLength is the total number of SHORTs occupied in the Events array up to
+and including the EndBriefing command, if present.
+
+Waypoint is the index of the briefing waypoint to use for flightgroup icons. 
+
+PageType is the index of the template to use for panel layout and visibility.
 
 Each Event is marked by the briefing time (in ticks) and the EventType,
 followed by 0-3 additional variables.  These variables are to be omitted if
 they are not used for a given command.  Unlike other platforms, the events list
 usually isn't terminated by an EndBriefing command.  Instead use EventsLength
 to get the actual length.
-
-EventsLength is the total number of SHORTs occupied in the Events array up to
-and including the EndBriefing command, if present.
 
 Following the briefing pages is the MissionHeader which contains redundant
 header information from the XWI file.  Most notable is the Location property
@@ -518,6 +543,8 @@ These are:
 0x01  Ends highlighting.
 '>'   If the first character on a line, creates yellow center-alignment text.
 
+NOTE: All briefing pages share the same Strings and Tags.
+
 XWING automatically generates word-wrapping.  The control codes 0x02, 0x01,
 and '>' will highlight only until the end of the current line.
 
@@ -543,10 +570,6 @@ EndEvent
 
 * Note: Old mission editors have incorrect values for Capture/Rescue.
 Capture has a proximity mechanism between friend and foe, results may vary.
-
-Location
-00	Deep Space
-01	Death Star Surface
 
 CraftType
 00	None
@@ -746,13 +769,15 @@ Order
 
 EventType
 00	None
-01	Wait For Click    (deprecated? doesn't seem to have any effect)
-0A	Clear Text (both Title and Caption)
-0B	Title Text
+01	Skip Marker   (break point for advancing, sometimes used in text pages)
+0A	Page Break    (clears all four string panels)
+0B	Title Text      (Panel 1, always used for title)
 	Var1	String#
-0C	Caption Text
+0C	Caption Text    (Panel 2, always used for caption)
 	Var1	String#
-0E	Caption Text 2    (deprecated? normally 0x0C is used instead)
+0D	Panel 3 Text    (typically unused)
+	Var1	String#
+0E	Panel 4 Text    (typically unused)
 	Var1	String#
 0F	Move Map
 	Var1	X
@@ -786,11 +811,22 @@ EventType
 	Var1	Tag#
 	Var2	X
 	Var3	Y
+1F	Clear Unknown Tag
+20	Unknown Tag
+	Var1	Unknown
+	Var2	Unknown
+	Var3	Unknown
 29	End Briefing
 
 Notes:
 String# and Tag# are zero-based indexes into the Strings and Tags.
 Icon# is a zero-based index into the BRF icon (FlightGroup) list.
+All strings and tags must be cleared before they can be replaced.  Applies to
+panel strings, FG tags, and text tags.
+The unknown tag accepts parameters.  Although it seems to be loaded when 
+encountered, it has no visible effect.
+There are some unlisted events that have nonzero parameter counts, but no
+handling in game.
 
 =====
 This documentation is distributed under the GNU Free Documentation License

--- a/Mission_XvT.txt
+++ b/Mission_XvT.txt
@@ -937,7 +937,7 @@ if attacked by the player. It is only false if attacked by AI, and only AI.
 When used as a goal, being attacked by anything (player or AI) is an anti-
 condition and will be immediately detected, resulting in instant failure. But
 there's another bug. If the player destroys the craft very quickly ("in 1 hit" 
-such as when using warheads), then "come-and-go" takes precendence over
+such as when using warheads), then "come-and-go" takes precedence over
 "attacked" and evaluates to success, even though it was attacked. But this bug
 only applies if the FG is one craft of one wave.
 

--- a/xwing/Briefing.cs
+++ b/xwing/Briefing.cs
@@ -42,11 +42,12 @@ namespace Idmr.Platform.Xwing
 	{
 		readonly Dictionary<EventType, string> _eventTypeStringMap = new Dictionary<EventType, string> {
 			{EventType.None, "None"},
-			{EventType.WaitForClick, "Wait For Click"},
-			{EventType.ClearText, "Clear Text"},
+			{EventType.SkipMarker, "Skip Marker"},
+			{EventType.PageBreak, "Page Break"},
 			{EventType.TitleText, "Title Text"},
 			{EventType.CaptionText, "Caption Text"},
-			{EventType.CaptionText2, "* Caption Text 2"},
+			{EventType.Panel3Text, "Panel 3 Text"},
+			{EventType.Panel4Text, "Panel 4 Text"},
 			{EventType.MoveMap, "Move Map"},
 			{EventType.ZoomMap, "Zoom Map"},
 			{EventType.ClearFGTags, "Clear FG Tags"},
@@ -66,24 +67,25 @@ namespace Idmr.Platform.Xwing
 		readonly static EventMap[] _eventMaps = {
 			// XWID, TIEID, PARAMS      NOTES
 			new EventMap(0, 0, 0),
-			new EventMap(1, 0, 0),		//01: Wait For Click. (No params)   --> None
-			new EventMap(10, 0x03, 0),	//10: Clear Text (No params)        --> Page Break (no params)
-			new EventMap(11, 0x04, 1),	//11: Display Title (textId)        --> Title Text (textId)
-			new EventMap(12, 0x05, 1),	//12: Display Main Text (textId)    --> Caption Text (textId)
-			new EventMap(14, 0x05, 1),	//14: Display Main Text 2 (textId)  --> Caption Text (textId)
-			new EventMap(15, 0x06, 2),	//15: Center Map (x, y)             --> Move Map (X,Y)
-			new EventMap(16, 0x07, 2),	//16: Zoom Map (xFactor, yFactor)   --> Zoom Map (X,Y)
-			new EventMap(21, 0x08, 0),	//21: Clear FG Tags (No params)     --> Clear FG Tags
-			new EventMap(22, 0x09, 1),	//22: Set FG Tag 1 (objectId)       --> FG Tag 1 (FGIndex)
-			new EventMap(23, 0x0A, 1),	//23: Set FG Tag 2 (objectId)       --> FG Tag 2 (FGIndex)
-			new EventMap(24, 0x0B, 1),	//24: Set FG Tag 3 (objectId)       --> FG Tag 3 (FGIndex)
-			new EventMap(25, 0x0C, 1),	//25: Set FG Tag 4 (objectId)       --> FG Tag 4 (FGIndex)
-			new EventMap(26, 0x11, 0),	//26: Clear Text Tags (No params)   --> Clear Text Tags
-			new EventMap(27, 0x12, 3),	//27: Create Tag 1 (tagId, x, y)    --> Text Tag 1 (tag, color, x, y)
-			new EventMap(28, 0x13, 3),	//28: Create Tag 2 (tagId, x, y)    --> Text Tag 2 (tag, color, x, y)
-			new EventMap(29, 0x14, 3),	//29: Create Tag 3 (tagId, x, y)    --> Text Tag 3 (tag, color, x, y)
-			new EventMap(30, 0x15, 3),	//30: Create Tag 4 (tagId, x, y)    --> Text Tag 4 (tag, color, x, y)
-			new EventMap(41, 0x22, 0)	//41: End marker                    --> End Briefing
+			new EventMap(1, 1, 0),		//01: Skip Marker                   --> Skip Marker
+			new EventMap(10, 0x03, 0),	//10: Page Break                    --> Page Break
+			new EventMap(11, 0x04, 1),	//11: Title Text (textId)           --> Title Text (textId)
+			new EventMap(12, 0x05, 1),	//12: Caption Text (textId)         --> Caption Text (textId)
+			new EventMap(13, 0x05, 1),	//14: Panel 3 Text (textId)         --> Caption Text (textId)
+			new EventMap(14, 0x05, 1),	//14: Panel 4 Text (textId)         --> Caption Text (textId)
+			new EventMap(15, 0x06, 2),	//15: Move Map (X, Y)               --> Move Map (X, Y)
+			new EventMap(16, 0x07, 2),	//16: Zoom Map (X, Y)               --> Zoom Map (X, Y)
+			new EventMap(21, 0x08, 0),	//21: Clear FG Tags                 --> Clear FG Tags
+			new EventMap(22, 0x09, 1),	//22: FG Tag 1 (objectId)           --> FG Tag 1 (FGIndex)
+			new EventMap(23, 0x0A, 1),	//23: FG Tag 2 (objectId)           --> FG Tag 2 (FGIndex)
+			new EventMap(24, 0x0B, 1),	//24: FG Tag 3 (objectId)           --> FG Tag 3 (FGIndex)
+			new EventMap(25, 0x0C, 1),	//25: FG Tag 4 (objectId)           --> FG Tag 4 (FGIndex)
+			new EventMap(26, 0x11, 0),	//26: Clear Text Tags               --> Clear Text Tags
+			new EventMap(27, 0x12, 3),	//27: Text Tag 1 (tag, x, y)        --> Text Tag 1 (tag, x, y, color)
+			new EventMap(28, 0x13, 3),	//28: Text Tag 2 (tag, x, y)        --> Text Tag 2 (tag, x, y, color)
+			new EventMap(29, 0x14, 3),	//29: Text Tag 3 (tag, x, y)        --> Text Tag 3 (tag, x, y, color)
+			new EventMap(30, 0x15, 3),	//30: Text Tag 4 (tag, x, y)        --> Text Tag 4 (tag, x, y, color)
+			new EventMap(41, 0x22, 0)	//41: End Briefing                  --> End Briefing
 		};
 		/// <summary>A single conversion of X-wing briefing event to TIE Fighter briefing event.</summary>
 		readonly struct EventMap
@@ -104,7 +106,7 @@ namespace Idmr.Platform.Xwing
 		}
 
 		/// <summary>Frames per second for briefing animation.</summary>
-		public const int TicksPerSecond = 8;
+		public const int TicksPerSecond = 10;
 		/// <summary>Maximum number of events that can be held.</summary>
 		public const int EventQuantityLimit = 200;
 
@@ -113,78 +115,76 @@ namespace Idmr.Platform.Xwing
 		{
 			/// <summary>No type defined.</summary>
 			None = 0,
-			/// <summary>Waits for the user to click the page to proceed.  Used to hide the special hints text.</summary>
-			WaitForClick = 1,
-			/// <summary>Clears both the title and caption text.</summary>
-			ClearText = 10,
-			/// <summary>Displays the specified text at the top of the briefing.</summary>
-			/// <remarks>Parameters:<br/>TextID</remarks>
+			/// <summary>Creates breakpoint for briefing interface <b>Next</b>.  If the map is not visible, waits for the user to click.</summary>
+			/// <remarks>Parameters:<br/>None</remarks>
+			SkipMarker = 1,
+			/// <summary>Clears all panel text, creates breakpoint for briefing interface <b>Next</b> command.</summary>
+			/// <remarks>Parameters:<br/>None</remarks>
+			PageBreak = 10,
+			/// <summary>Displays the specified text in the first panel, typically at the top of the briefing.</summary>
+			/// <remarks>Parameters:<br/>String #</remarks>
 			TitleText,
-			/// <summary>Displays the specified text at the bottom of the briefing.</summary>
-			/// <remarks>Parameters:<br/>TextID</remarks>
+			/// <summary>Displays the specified text in the second panel, typically at the bottom of the briefing.</summary>
+			/// <remarks>Parameters:<br/>String #</remarks>
 			CaptionText,
-			/// <summary>Alternate command used in some briefings.  If at tick 700, it's an end marker.</summary>
-			/// <remarks>Parameters:<br/>TextID</remarks>
-			CaptionText2 = 14,
+			/// <summary>Displays the specified text in the third panel, typically unused.</summary>
+			/// <remarks>Parameters:<br/>String #</remarks>
+			Panel3Text,
+			/// <summary>Displays the specified text in the fourth panel, typically unused.</summary>
+			/// <remarks>Parameters:<br/>String #</remarks>
+			Panel4Text,
 			/// <summary>Change the focal point of the map.</summary>
 			/// <remarks>Parameters:<br/>X coord, Y coord</remarks>
 			MoveMap,
 			/// <summary>Change the zoom distance of the map.</summary>
-			/// <remarks>Parameters:<br/>X factor, Y factor</remarks>
+			/// <remarks>Parameters:<br/>X zoom, Y zoom</remarks>
 			ZoomMap,
 			/// <summary>Erase all FlightGroup tags from view.</summary>
+			/// <remarks>Parameters:<br/>None</remarks>
 			ClearFGTags = 21,
 			/// <summary>Apply a FlightGroup tag using slot 1.</summary>
-			/// <remarks>Parameters:<br/>ObjectID</remarks>
+			/// <remarks>Parameters:<br/>Briefing FG #</remarks>
 			FGTag1,
 			/// <summary>Apply a FlightGroup tag using slot 2.</summary>
-			/// <remarks>Parameters:<br/>ObjectID</remarks>
+			/// <remarks>Parameters:<br/>Briefing FG #</remarks>
 			FGTag2,
 			/// <summary>Apply a FlightGroup tag using slot 3.</summary>
-			/// <remarks>Parameters:<br/>ObjectID</remarks>
+			/// <remarks>Parameters:<br/>Briefing FG #</remarks>
 			FGTag3,
 			/// <summary>Apply a FlightGroup tag using slot 4.</summary>
-			/// <remarks>Parameters:<br/>ObjectID</remarks>
+			/// <remarks>Parameters:<br/>Briefing FG #</remarks>
 			FGTag4,
 			/// <summary>Erase all text tags from view.</summary>
+			/// <remarks>Parameters:<br/>None</remarks>
 			ClearTextTags,
 			/// <summary>Apply a text tag using slot 1.</summary>
-			/// <remarks>Parameters:<br/>TagID, X coord, Y coord</remarks>
+			/// <remarks>Parameters:<br/>Tag #, X coord, Y coord</remarks>
 			TextTag1,
 			/// <summary>Apply a text tag using slot 2.</summary>
-			/// <remarks>Parameters:<br/>TagID, X coord, Y coord</remarks>
+			/// <remarks>Parameters:<br/>Tag #, X coord, Y coord</remarks>
 			TextTag2,
 			/// <summary>Apply a text tag using slot 3.</summary>
-			/// <remarks>Parameters:<br/>TagID, X coord, Y coord</remarks>
+			/// <remarks>Parameters:<br/>Tag #, X coord, Y coord</remarks>
 			TextTag3,
 			/// <summary>Apply a text tag using slot 4.</summary>
-			/// <remarks>Parameters:<br/>TagID, X coord, Y coord</remarks>
+			/// <remarks>Parameters:<br/>Tag #, X coord, Y coord</remarks>
 			TextTag4,
 			/// <summary>End of briefing marker.</summary>
 			EndBriefing = 41
 		};
 
-		/// <summary>The types available to a <see cref="BriefingPage"/>.</summary>
-		public enum PageType : short
-		{
-			/// <summary>Renders a briefing map</summary>
-			Map = 0,
-			/// <summary>Renders text</summary>
-			Text = 1
-		};
-
 		/// <summary>Initializes a blank Briefing.</summary>
 		public Briefing()
 		{   //initialize
-			MaxCoordSet = 2;
+			MaxWaypoints = 2;
 			Pages = new List<BriefingPage>
 			{
 				new BriefingPage()
 			};
 			Pages[0].SetDefaultFirstPage();
 
-			WindowSettings = new List<BriefingUIPage>();
-			ResetUISettings(2);
+			Templates = new List<PageTemplate>();
+			ResetTemplates(2);
 
 			_platform = MissionFile.Platform.Xwing;
 			Length = 45 * TicksPerSecond;
@@ -385,20 +385,19 @@ namespace Idmr.Platform.Xwing
 		/// <exception cref="IndexOutOfRangeException"><paramref name="page"/> is not valid.</exception>
 		public int GetEventsLength(int page) => GetBriefingPage(page).Events.Length;
 
-		/// <summary>Resets the pages to default.</summary>
-		/// <param name="pageTypeCount">The number of page types, must be at least <b>2</b>.</param>
-		/// <remarks>The first will be a default <see cref="PageType.Map"/>, the second will be a default <see cref="PageType.Text"/>.</remarks>
-		public void ResetUISettings(int pageTypeCount)
+		/// <summary>Resets the pages templates to default.</summary>
+		/// <param name="pageTypeCount">The number of page type templates, must be at least <b>2</b>.</param>
+		/// <remarks>The default configuration has two templates: a map page and text page, in that order.</remarks>
+		public void ResetTemplates(int pageTypeCount)
 		{
-			//Default to 2 page types, Map and Text.
 			if (pageTypeCount < 2)
 				pageTypeCount = 2;
-			WindowSettings.Clear();
+			Templates.Clear();
 			for (int i = 0; i < pageTypeCount; i++)
-				WindowSettings.Add(new BriefingUIPage());
+				Templates.Add(new PageTemplate());
 
-			WindowSettings[0].SetDefaultsToMapPage();
-			WindowSettings[1].SetDefaultsToTextPage();
+			Templates[0].SetDefaultsToMapPage();
+			Templates[1].SetDefaultsToTextPage();
 		}
 
 		/// <summary>Gets the index of the matching <see cref="BaseBriefing.BriefingString"/>.</summary>
@@ -464,13 +463,13 @@ namespace Idmr.Platform.Xwing
 			return (int)EventType.None;
 		}
 
-		/// <summary>Gets if the selected <see cref="BriefingPage"/> has a visible <see cref="BriefingUIPage.Elements.Map"/>.</summary>
+		/// <summary>Gets if the selected <see cref="BriefingPage"/> has a visible <see cref="PageTemplate.Elements.Map"/>.</summary>
 		/// <param name="page">The selected page.</param>
 		/// <returns><b>true</b> is it's visible. Any errors or otherwise returns <b>false</b>.</returns>
 		public bool IsMapPage(int page)
 		{
 			if (page < 0 || page >= Pages.Count) return false;
-			return WindowSettings[Pages[page].PageType].GetElement(BriefingUIPage.Elements.Map).IsVisible;
+			return Templates[Pages[page].PageType].GetElement(PageTemplate.Elements.Map).IsVisible;
 		}
 
 		/// <summary>Enumerates a list of caption strings found in a briefing page.</summary>
@@ -499,17 +498,19 @@ namespace Idmr.Platform.Xwing
 		/// <exception cref="InvalidOperationException">Throws on any get attempt.</exception>
 		new public short EventsLength => throw new InvalidOperationException("Warning! EventsLength is not used for X-wing briefings. If you see this message, please file a bug report.");
 
-		/// <summary>The number of CoordinateSets in the Briefing.</summary>
+		/// <summary>The number of Waypoints for each icon in the Briefing.</summary>
 		/// <remarks>Defaults to <b>2</b>.</remarks>
-		public short MaxCoordSet { get; set; }
-		/// <summary>Gets or sets where the mission takes place.</summary>
+		public short MaxWaypoints { get; set; }
+		/// <summary>Gets or sets whether the location is a Death Star surface mission.</summary>
 		/// <remarks>Same as <see cref="Mission.Location"/>. Will affect the briefing background.</remarks>
-		public short MissionLocation { get; set; }
+		public bool MissionLocation { get; set; }
 
 		/// <summary>Collection of Briefing pages.</summary>
+		/// <remarks>Maximum length should not exceed 8 items.</remarks>
 		public List<BriefingPage> Pages { get; private set; }
-		/// <summary>Collection of window settings.</summary>
-		public List<BriefingUIPage> WindowSettings { get; private set; }
+		/// <summary>Collection of page templates.</summary>
+		/// <remarks>Maximum length should not exceed 4 items.</remarks>
+		public List<PageTemplate> Templates { get; private set; }
 
 		/// <summary>Singleton object to maintain a read-only array.</summary>
 		new public class EventParameters
@@ -518,7 +519,7 @@ namespace Idmr.Platform.Xwing
 
 			// X-wing uses different counts, so redo the class
 			// -----------------------  0  1  2  3  4  5  6  7  8  9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41
-			readonly byte[] _counts = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 2, 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
+			readonly byte[] _counts = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 0, 0, 0, 0, 0, 1, 1, 1, 1, 0, 3, 3, 3, 3, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 			private EventParameters() { }
 
@@ -538,8 +539,8 @@ namespace Idmr.Platform.Xwing
 	}
 
 	//Thanks to the XWVM team for providing documentation on this block.
-	/// <summary>Object for element location and dimensions.</summary>
-	public class BriefingUIItem
+	/// <summary>Object for panel element location, size, and visibility.</summary>
+	public class PagePanel
 	{
 		/// <summary>Gets or sets the top pixel location.</summary>
 		public short Top { get; set; }
@@ -553,43 +554,43 @@ namespace Idmr.Platform.Xwing
 		public bool IsVisible { get; set; }
 	}
 
-	/// <summary>Object for the window settings.</summary>
-	public class BriefingUIPage
+	/// <summary>Object for the briefing page screen template.</summary>
+	public class PageTemplate
 	{
-		/// <summary>Gets the viewport settings array.</summary>
-		public BriefingUIItem[] Items { get; private set; }
+		/// <summary>Gets the panel settings array.</summary>
+		public PagePanel[] Items { get; private set; }
 
-		/// <summary>The valid viewport elements.</summary>
+		/// <summary>The valid panel elements.</summary>
 		public enum Elements
 		{
 			/// <summary>The title text.</summary>
 			Title = 0,
 			/// <summary>The caption text.</summary>
-			Text,
-			/// <summary>Unused.</summary>
-			Unused1,
-			/// <summary>Unused.</summary>
-			Unused2,
+			Caption,
+			/// <summary>Extra text panel, typically unused.</summary>
+			Panel3,
+			/// <summary>Extra text panel, typically unused.</summary>
+			Panel4,
 			/// <summary>The briefing map.</summary>
 			Map
 		}
 
-		/// <summary>Initializes a new window.</summary>
-		public BriefingUIPage()
+		/// <summary>Initializes a new page template.</summary>
+		public PageTemplate()
 		{
-			Items = new BriefingUIItem[5];
+			Items = new PagePanel[5];
 			for (int i = 0; i < 5; i++)
-				Items[i] = new BriefingUIItem();
+				Items[i] = new PagePanel();
 		}
 
-		/// <summary>Gets the item via the enumerated value.</summary>
+		/// <summary>Gets a panel via its enumerated value.</summary>
 		/// <param name="item">The specified element value.</param>
 		/// <returns>The requested item.</returns>
-		public BriefingUIItem GetElement(Elements item) => Items[(int)item];
+		public PagePanel GetElement(Elements item) => Items[(int)item];
 		/// <summary>Gets the type of page.</summary>
-		/// <returns>If the <see cref="Elements.Map"/> viewport is visible, "Map", otherwise "Text".</returns>
+		/// <returns>If the <see cref="Elements.Map"/> panel is visible, "Map", otherwise "Text".</returns>
 		public string GetPageDesc() => Items[(int)Elements.Map].IsVisible ? "Map" : "Text";
-		/// <summary>Assigns default map data.</summary>
+		/// <summary>Assigns default values for a map page, including title and caption in their standard locations.</summary>
 		/// <remarks>Sets the <see cref="Elements.Map"/> visibility to <b>1</b>.</remarks>
 		public void SetDefaultsToMapPage()
 		{
@@ -600,7 +601,7 @@ namespace Idmr.Platform.Xwing
 								 {12, 0, 115, 212, 1} };
 			setRawData(defData);
 		}
-		/// <summary>Assigns default text data.</summary>
+		/// <summary>Assigns default values for a text page, containing a title and extra large caption area.</summary>
 		/// <remarks>Sets the <see cref="Elements.Map"/> visibility to <b>0</b>.</remarks>
 		public void SetDefaultsToTextPage()
 		{
@@ -621,7 +622,7 @@ namespace Idmr.Platform.Xwing
 				throw new ArgumentException("Not enough data elements.");
 			for (int i = 0; i < 5; i++)
 			{
-				BriefingUIItem item = Items[i];
+				PagePanel item = Items[i];
 				item.Top = data[i, 0];
 				item.Left = data[i, 1];
 				item.Bottom = data[i, 2];
@@ -640,11 +641,11 @@ namespace Idmr.Platform.Xwing
 		public BriefingPage() => Events = new Briefing.EventCollection();
 
 		/// <summary>Set the initial events and <see cref="Briefing.EventType.EndBriefing"/>.</summary>
-		/// <remarks><see cref="CoordSet"/> is set to <b>1</b>, duration is set to <b>45 seconds</b>.
+		/// <remarks><see cref="Waypoint"/> is set to <b>1</b>, duration is set to <b>45 seconds</b>.
 		/// Initial events center map on (0,0), move map to (0x30, 0x30) and apply the end marker at time 9999.</remarks>
 		public void SetDefaultFirstPage()
 		{
-			CoordSet = 1;
+			Waypoint = 1;
 			Length = 45 * Briefing.TicksPerSecond;
 			Events.Add(new Briefing.Event(Briefing.EventType.MoveMap));
 			Events.Add(new Briefing.Event(Briefing.EventType.ZoomMap) { Variables = new short[] { 0x30, 0x30 } });
@@ -653,13 +654,13 @@ namespace Idmr.Platform.Xwing
 		/// <summary>Gets the raw event data.</summary>
 		public Briefing.EventCollection Events { get; internal set; }
 		/// <summary>Gets or sets the briefing length in ticks.</summary>
-		/// <remarks>Xwing uses 8 ticks per second.</remarks>
+		/// <remarks>Xwing uses about 10 ticks per second.</remarks>
 		public short Length { get; set; }
 		/// <summary>Gets the total number of values occupied in <see cref="Events"/>.</summary>
 		public short EventsLength => Events.Length;
-		/// <summary>Gets or sets the applicable Waypoint coordinate set index.</summary>
-		public short CoordSet { get; set; }
-		/// <summary>Gets or sets if the page is <see cref="Briefing.PageType.Map"/> or <see cref="Briefing.PageType.Text"/>.</summary>
-		public short PageType { get; set; }	// TODO XW: this really should be the enum, but need more research to see if >= 2 values are possible
+		/// <summary>Gets or sets the applicable Waypoint set index.</summary>
+		public short Waypoint { get; set; }
+		/// <summary>Gets or sets the page type template index.</summary>
+		public short PageType { get; set; }
 	}
 }

--- a/xwing/FlightGroup.cs
+++ b/xwing/FlightGroup.cs
@@ -185,11 +185,12 @@ namespace Idmr.Platform.Xwing
 		/// <summary>Gets a string representation of the FlightGroup.</summary>
 		/// <returns>Short representation of the FlightGroup as <b>"CraftAbbrv Name"</b>.</returns>
 		public override string ToString() => ToString(false);
-		/// <summary>Gets a string representation of the FlightGroup.</summary>
+		/// <summary>Gets a string representation of a mission FlightGroup.</summary>
 		/// <remarks>Short form is <b>"<see cref="Strings.CraftAbbrv"/>.<see cref="BaseFlightGroup.Name"/></b>.
 		/// <br/>Long form is <b>"<see cref="BaseFlightGroup.IFF"/> - <see cref="BaseFlightGroup.GlobalGroup">GG</see>
 		/// - IsPlayer <see cref="BaseFlightGroup.NumberOfWaves"/> x <see cref="BaseFlightGroup.NumberOfCraft"/>.
-		/// <see cref="Strings.CraftAbbrv"/>.<see cref="BaseFlightGroup.Name"/>"</b>.</remarks>
+		/// <see cref="Strings.CraftAbbrv"/>.<see cref="BaseFlightGroup.Name"/>"</b>.
+		/// <br/>For briefing flightgroups, see <see cref="BriefingString"/> instead.</remarks>
 		/// <param name="verbose">When <b>true</b> returns long form.</param>
 		/// <returns>Representation of the FlightGroup.</returns>
 		public string ToString(bool verbose)
@@ -226,11 +227,22 @@ namespace Idmr.Platform.Xwing
             return IFF + " - " + (PlayerCraft != 0 ? "*" : "") + waves + " " + longName;
 		}
 
-		public string BriefingString()
+		/// <summary>Gets a string representation of the briefing FlightGroup.</summary>
+		/// <remarks>Alternative to <see cref="ToString"/> intended specifically for briefing flightgroups.
+		/// <br/>Whether a flightgroup belongs to the briefing collection can't be inferred on context, so it must be explicitly called.
+		/// <br/>Short form is <b>"<see cref="Strings.BriefingObjectType"/>.<see cref="BaseFlightGroup.Name"/>"</b>.
+		/// <br/>Long form is <b>"<see cref="BaseFlightGroup.NumberOfWaves"/> x <see cref="BaseFlightGroup.NumberOfCraft"/>.
+		/// <see cref="Strings.BriefingObjectType"/>.<see cref="BaseFlightGroup.Name"/>"</b>.</remarks>
+		/// <param name="verbose">When <b>true</b> returns long form.  Accepted for craft only, otherwise returns short form.</param>
+		/// <returns>Representation of the FlightGroup.</returns>
+		public string BriefingString(bool verbose)
 		{
 			string[] objTypes = Strings.BriefingObjectType;
 			int index = IsObjectGroup() ? ObjectType : CraftType;
-			return (index >= 0 && index < objTypes.Length ? objTypes[index] : index.ToString());
+			string result = (index >= 0 && index < objTypes.Length ? objTypes[index] : index.ToString()) + " " + Name;
+			if (verbose && (IsFlightGroup() || ObjectType == 25))
+				result = (NumberOfWaves + 1) + "x" + NumberOfCraft + " " + result;
+			return result;
 		}
 
 		/// <summary>Gets the actual IFF code as it would appear in game.</summary>

--- a/xwing/FlightGroup.cs
+++ b/xwing/FlightGroup.cs
@@ -67,22 +67,22 @@ namespace Idmr.Platform.Xwing
 			Start3,
 			/// <summary>Arrival and Departure coordinate.</summary>
 			Hyperspace,
-			/// <summary>Coordinate Set 1.</summary>
-			CS1,
-			/// <summary>Coordinate Set 2.</summary>
-			CS2,
-			/// <summary>Coordinate Set 3.</summary>
-			CS3,
-			/// <summary>Coordinate Set 4.</summary>
-			CS4,
-			/// <summary>Coordinate Set 5.</summary>
-			CS5,
-			/// <summary>Coordinate Set 6.</summary>
-			CS6,
-			/// <summary>Coordinate Set 7.</summary>
-			CS7,
-			/// <summary>Coordinate Set 8.</summary>
-			CS8
+			/// <summary>Virtualized briefing coordinate 1.</summary>
+			Briefing1,
+			/// <summary>Virtualized briefing coordinate 2.</summary>
+			Briefing2,
+			/// <summary>Virtualized briefing coordinate 3.</summary>
+			Briefing3,
+			/// <summary>Virtualized briefing coordinate 4.</summary>
+			Briefing4,
+			/// <summary>Virtualized briefing coordinate 5.</summary>
+			Briefing5,
+			/// <summary>Virtualized briefing coordinate 6.</summary>
+			Briefing6,
+			/// <summary>Virtualized briefing coordinate 7.</summary>
+			Briefing7,
+			/// <summary>Virtualized briefing coordinate 8.</summary>
+			Briefing8
 		}
 
 		/// <summary>Available orders.</summary>
@@ -200,16 +200,23 @@ namespace Idmr.Platform.Xwing
 			{
 				int index = ObjectType - 17;
 				if (index < 0) index = 0;
-				longName = "{" + Strings.ObjectType[index] + "} " + Name;
+				string[] objStrings = Strings.ObjectType;
+				if(index < objStrings.Length)
+					longName = "{" + objStrings[index] + "} " + Name;
+				else
+					longName = "{Object " + index + "} " + Name;
 			}
 			else
 			{
-				if (CraftType == 2 && Status1 >= 10)  // Index hack for B-wings
-					longName = Strings.CraftAbbrv[18] + " " + Name;
+				string[] abbrevStrings = Strings.CraftAbbrv;
+				if (CraftType == 2 && Status1 >= 10)
+					longName = abbrevStrings[18] + " " + Name;
 				else if (CraftType == 25)
-					longName = Strings.CraftAbbrv[18] + " " + Name;
+					longName = abbrevStrings[18] + " " + Name;
+				else if(CraftType < abbrevStrings.Length)
+					longName = abbrevStrings[CraftType] + " " + Name;
 				else
-					longName = Strings.CraftAbbrv[CraftType] + " " + Name;
+					longName = "Craft " + CraftType + " " + Name;
 
 				if (EditorCraftNumber > 0) //[JB] Added numbering information.
 					longName += EditorCraftExplicit ? " " + EditorCraftNumber : " <" + EditorCraftNumber + ">";
@@ -217,6 +224,13 @@ namespace Idmr.Platform.Xwing
 
 			if (!verbose) return longName;
             return IFF + " - " + (PlayerCraft != 0 ? "*" : "") + waves + " " + longName;
+		}
+
+		public string BriefingString()
+		{
+			string[] objTypes = Strings.BriefingObjectType;
+			int index = IsObjectGroup() ? ObjectType : CraftType;
+			return (index >= 0 && index < objTypes.Length ? objTypes[index] : index.ToString());
 		}
 
 		/// <summary>Gets the actual IFF code as it would appear in game.</summary>

--- a/xwing/Mission.cs
+++ b/xwing/Mission.cs
@@ -185,15 +185,15 @@ namespace Idmr.Platform.Xwing
 			s = br.ReadInt16(); //PlatformID
 			if (s != 2) throw new InvalidDataException("Not a valid X-wing briefing file.");
 			short shipCount = br.ReadInt16();
-			short coordCount = br.ReadInt16();
+			short wayptCount = br.ReadInt16();
 			FlightGroupsBriefing = new FlightGroupCollection(shipCount);
 			int wp;
-			for (int i = 0; i < coordCount; i++)
+			for (int i = 0; i < wayptCount; i++)
 			{
 				//Just in case there too many coord sets than what the editor allows, read them but only load them if the indexes are valid.
 				if (i == 0) wp = (byte)FlightGroup.WaypointIndex.Start1;
-				else wp = (byte)FlightGroup.WaypointIndex.CS1 + i - 1;  //at this point i==1 so subtract to compensate
-				if (wp >= (byte)FlightGroup.WaypointIndex.CS4)
+				else wp = (byte)FlightGroup.WaypointIndex.Briefing1 + i - 1;  //at this point i==1 so subtract to compensate
+				if (wp >= (byte)FlightGroup.WaypointIndex.Briefing4)
 					wp = -1;
 				for (int j = 0; j < shipCount; j++)
 				{
@@ -207,9 +207,9 @@ namespace Idmr.Platform.Xwing
 						FlightGroupsBriefing[j].Waypoints[wp].Enabled = true;
 				}
 			}
-			if (coordCount < 2) coordCount = 2;  //Sanity check for editor purposes.  All LEC missions have 2 sets.
-			else if (coordCount > 4) coordCount = 4;
-			Briefing.MaxCoordSet = coordCount;
+			if (wayptCount < 2) wayptCount = 2;  //Sanity check for editor purposes.  All LEC missions have 2 sets.
+			else if (wayptCount > 4) wayptCount = 4;
+			Briefing.MaxWaypoints = wayptCount;
 
 			for (int i = 0; i < shipCount; i++)
 			{
@@ -237,14 +237,14 @@ namespace Idmr.Platform.Xwing
 				FlightGroupsBriefing[i].Roll = br.ReadInt16();
 			}
 
-			#region WindowUISettings
-			short count = br.ReadInt16();  //Setting count.  Usually 2, but not always.
-			Briefing.ResetUISettings(count);
+			#region PageTemplates
+			short count = br.ReadInt16();  // Template count.  Usually 2, but not always.
+			Briefing.ResetTemplates(count);
 			for (int i = 0; i < count; i++)
 			{
 				for (int j = 0; j < 5; j++)
 				{
-					BriefingUIItem item = Briefing.WindowSettings[i].Items[j];
+					PagePanel item = Briefing.Templates[i].Items[j];
 					item.Top = br.ReadInt16();
 					item.Left = br.ReadInt16();
 					item.Bottom = br.ReadInt16();
@@ -252,7 +252,7 @@ namespace Idmr.Platform.Xwing
 					item.IsVisible = Convert.ToBoolean(br.ReadInt16());
 				}
 			}
-			#endregion WindowUISettings
+			#endregion PageTemplates
 
 			#region Pages
 			count = br.ReadInt16();
@@ -262,7 +262,7 @@ namespace Idmr.Platform.Xwing
 				BriefingPage pg = Briefing.Pages[i];
 				pg.Length = br.ReadInt16(); //total ticks
 				short len = br.ReadInt16();  //EventsLength
-				pg.CoordSet = br.ReadInt16();
+				pg.Waypoint = br.ReadInt16();
 				pg.PageType = br.ReadInt16();
 
 				byte[] briefBuffer = br.ReadBytes(len * 2);
@@ -275,7 +275,7 @@ namespace Idmr.Platform.Xwing
 			/*s = br.ReadInt16();  //TimeLimitMinutes?
 			s = br.ReadInt16();  //EndEvent?
 			s = br.ReadInt16();  //Unknown1?*/
-			Briefing.MissionLocation = br.ReadInt16();
+			Briefing.MissionLocation = Convert.ToBoolean(br.ReadInt16());
 			stream.Position += 3 * 64;
 			/*for (int i = 0; i < 3; i++)  //EndOfMissionMessages
 				str = new string(br.ReadChars(64));*/
@@ -483,15 +483,15 @@ namespace Idmr.Platform.Xwing
 				writerCreated = true;
 				bw.Write((short)2);   //Version
 				bw.Write((short)FlightGroupsBriefing.Count);
-				bw.Write(Briefing.MaxCoordSet);  //Coordinate count;
+				bw.Write(Briefing.MaxWaypoints);  //waypoint count
 				long p = 0;
 				int wp = 0;
-				for (int i = 0; i < Briefing.MaxCoordSet; i++)  //Coordinate count
+				for (int i = 0; i < Briefing.MaxWaypoints; i++)
 				{
-					//Just in case there too many coord sets than what the editor allows, read them but only load them if the indexes are valid.
+					//Just in case there too many waypoints than what the editor allows, read them but only load them if the indexes are valid.
 					if (i == 0) wp = 0;  //SP1
 					else
-						wp = 7 + i - 1;  //CS1 starts at [7], but at this point i==1 so subtract to compensate
+						wp = 7 + i - 1;  //WP1 starts at [7], but at this point i==1 so subtract to compensate
 					if (wp >= 10)
 						wp = -1;
 
@@ -532,14 +532,14 @@ namespace Idmr.Platform.Xwing
 					bw.Write(FlightGroupsBriefing[i].Roll);
 				}
 
-				#region WindowUISettings
-				short count = (short)Briefing.WindowSettings.Count;
+				#region Page templates
+				short count = (short)Briefing.Templates.Count;
 				bw.Write(count);
 				for (int i = 0; i < count; i++)
 				{
 					for (int j = 0; j < 5; j++)
 					{
-						BriefingUIItem item = Briefing.WindowSettings[i].Items[j];
+						PagePanel item = Briefing.Templates[i].Items[j];
 						bw.Write(item.Top);
 						bw.Write(item.Left);
 						bw.Write(item.Bottom);
@@ -547,7 +547,7 @@ namespace Idmr.Platform.Xwing
 						bw.Write(Convert.ToInt16(item.IsVisible));
 					}
 				}
-				#endregion WindowUISettings
+				#endregion Page templates
 
 				#region Pages
 				bw.Write((short)Briefing.Pages.Count);
@@ -556,7 +556,7 @@ namespace Idmr.Platform.Xwing
 					BriefingPage pg = Briefing.GetBriefingPage(i);
 					bw.Write(pg.Length);
 					bw.Write(pg.EventsLength);
-					bw.Write(pg.CoordSet);
+					bw.Write(pg.Waypoint);
 					bw.Write(pg.PageType);
 
 					byte[] briefBuffer = new byte[pg.Events.Length * 2];	// X-wing is unique that this is dynamic, other platforms use EventQuantityLimit
@@ -568,7 +568,7 @@ namespace Idmr.Platform.Xwing
 				bw.Write(TimeLimitMinutes);
 				bw.Write(EndEvent);
 				bw.Write(RndSeed);
-				bw.Write(Briefing.MissionLocation);
+				bw.Write(Convert.ToInt16(Briefing.MissionLocation));
 
 				p = fs.Position;
 				for (int i = 0; i < 3; i++)

--- a/xwing/Strings.cs
+++ b/xwing/Strings.cs
@@ -148,6 +148,118 @@ namespace Idmr.Platform.Xwing
 									  };
 
 
+		static readonly string[] _briefingObjectType = {
+			"None",
+			"X-W",
+			"Y-W",
+			"A-W",
+			"T/F",
+			"T/I",
+			"T/B",
+			"GUN",
+			"TRN",
+			"SHU",
+			"TUG", // 10
+			"CON",
+			"FRT",
+			"CRS",
+			"FRG",
+			"CRV",
+			"STD",
+			"T/A",
+			"Mine1",
+			"Mine2",
+			"Mine3",  // 20
+			"Mine4",
+			"Satellite",
+			"Nav Buoy",
+			"Probe",
+			"B-W",
+			"Asteroid 1",
+			"Asteroid 2",
+			"Asteroid 3",
+			"Asteroid 4",
+			"Asteroid 5",  // 30
+			"Asteroid 6",
+			"Asteroid 7",
+			"Asteroid 8",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",  // 40
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Planet",
+			"Death Star",
+			"Spiral", // 50
+			"Spiral",
+			"Spiral",
+			"Spiral",
+			"Spiral",
+			"Spiral",
+			"Spiral",
+			"Spiral",
+			"Start Gate",
+			"Gate 1A",
+			"Gate 1B",  // 60
+			"Gate 1C",
+			"Gate 2A",
+			"Gate 2B",
+			"Gate 2C",
+			"Gate 3A",
+			"Gate 3B",
+			"Gate 3C",
+			"Gate 4A",
+			"Gate 4B",
+			"Gate 4C", // 70
+			"Gate 5A",
+			"Gate 5B",
+			"Gate 5C",
+			"Gate 6A",
+			"Gate 6B",
+			"Gate 6C",
+			"Thing 1",
+			"Thing 1",
+			"Thing 1",
+			"Thing 1", // 80
+			"Thing 1",
+			"Thing 1",
+			"Thing 1",
+			"Thing 1",
+			"Thing 2",
+			"Thing 2",
+			"Thing 2",
+			"Thing 2",
+			"Thing 2",
+			"Thing 2", // 90
+			"Thing 2",
+			"Thing 2",
+			"Thing 3A",
+			"Thing 3B",
+			"Thing 3C",
+			"Thing 3D",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4", // 100
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+			"Thing 4",
+		};
+
         /*
          * Mapping gun turrets around the gates on Training Platform.
          * (assuming a "front-facing" platform, player and platform guns facing each other)
@@ -335,10 +447,10 @@ namespace Idmr.Platform.Xwing
 									"Hit Exhaust Port"
 									 };
         
-        static readonly string[] _briefingUIElement = { "Title",
-                                               "Text",
-                                               "Unused1",
-                                               "Unused2",
+        static readonly string[] _pagePanels = { "Title",
+                                               "Caption",
+                                               "Panel3",
+                                               "Panel4",
                                                "Map"
                                              };
         
@@ -393,6 +505,9 @@ namespace Idmr.Platform.Xwing
 		/// <summary>Gets a copy of the long names for object types.  NOTE: X-wing distinguishes between craft FGs and object FGs as separate entities.</summary>
 		/// <remarks>Array is Length = 33.</remarks>
 		public static string[] ObjectType => (string[])_objectType.Clone();
+		/// <summary>Gets a copy of the abbreviated names for object types, as they exist for briefing icons.  It is a combination of CraftAbbrv and ObjectType, with some changes.</summary>
+		/// <remarks>Array is Length = 108.</remarks>
+		public static string[] BriefingObjectType => (string[])_briefingObjectType.Clone();
 		/// <summary>Gets a copy of the short names for ship types.</summary>
 		/// <remarks>Array is Length = 88.</remarks>
 		public static string[] CraftAbbrv => (string[])_craftAbbrv.Clone();
@@ -438,7 +553,7 @@ namespace Idmr.Platform.Xwing
 
 		/// <summary>Gets a copy of the briefing UI element names.</summary>
 		/// <remarks>Array is Length = 5.</remarks>
-		public static string[] BriefingUIElement => (string[])_briefingUIElement.Clone();
+		public static string[] PagePanels => (string[])_pagePanels.Clone();
 
 		/// <summary>Gets a copy of the order parameter (docktime/throttle) Throttle percentage description.</summary>
 		/// <remarks>Array is Length = 11.</remarks>


### PR DESCRIPTION
Some classes and vars renamed to be more intuitive.  This isn't an exhaustive list of changes, but generally:
BriefingUIPage -> PageTemplate
BriefingUIItem -> PagePanel
WindowUISettings -> Templates
CoordSet -> Waypoint

Events renamed to bring in line with the other platforms, since they do the same things.
WaitForClick -> SkipMarker
ClearText -> PageBreak

Auxiliary string panels and events named and added (Panel3, Panel4)

Deleted PageType enum due to name ambiguity, and also obsolete since it actually refers to the page template, which can technically be anything depending on how it's customized.

MissionLocation changed to Bool since that's how it behaves, but still a Short in the format spec.

New string list for the briefing icons, since it's a bit different from the ObjectType list.

Format doc updated accordingly, rewrote material for PageTemplate and PagePanel, added unknown events, clarified some other aspects of the spec.